### PR TITLE
fix(desktop): create the window visible to end the hidden-window race

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -115,10 +115,11 @@ type App struct {
 	// Production wiring keeps it nil.
 	quitFn func(ctx context.Context)
 
-	// windowShowFn, when non-nil, replaces wailsRuntime.WindowShow in the
-	// close guard. Lets tests run the interception path without a live Wails
-	// runtime (wailsRuntime panics on a foreign context). Production wiring
-	// keeps it nil.
+	// windowShowFn, when non-nil, replaces wailsRuntime.WindowShow in
+	// showWindow — and therefore on every path that reveals the window (the
+	// startup phases, OnDomReady, and the close guard). Lets tests observe
+	// those paths without a live Wails runtime (wailsRuntime panics on a
+	// foreign context). Production wiring keeps it nil.
 	windowShowFn func(ctx context.Context)
 }
 
@@ -245,6 +246,22 @@ func (a *App) emit(eventName string, optionalData ...any) {
 		return
 	}
 	wailsRuntime.EventsEmit(a.ctx, eventName, optionalData...)
+}
+
+// showWindow reveals the main window. Tests can inject a fake by setting
+// a.windowShowFn; production code uses wailsRuntime.WindowShow.
+//
+// Every reveal path funnels through here, and all of them are idempotent:
+// showing an already-visible window is a no-op. The window is created visible
+// (main.go sets no StartHidden), so in a normal start these calls have nothing
+// left to do — they exist so a window that is hidden for any other reason
+// still comes back.
+func (a *App) showWindow(ctx context.Context) {
+	if a.windowShowFn != nil {
+		a.windowShowFn(ctx)
+		return
+	}
+	wailsRuntime.WindowShow(ctx)
 }
 
 // resolvePendingMessage delegates to FrontendAPI.ResolvePendingMessage to mark

--- a/desktop/exit_guard.go
+++ b/desktop/exit_guard.go
@@ -84,11 +84,7 @@ func (a *App) ShouldPreventClose(_ context.Context) bool {
 	// request. a.emit tolerates a nil ctx (Startup not run yet) by dropping
 	// the event with a warning, but that window cannot have active sessions.
 	if a.ctx != nil {
-		if a.windowShowFn != nil {
-			a.windowShowFn(a.ctx)
-		} else {
-			wailsRuntime.WindowShow(a.ctx)
-		}
+		a.showWindow(a.ctx)
 	}
 	a.emit(EventAppExitRequested, exitGuardPayload{
 		Sessions:      active,

--- a/desktop/startup.go
+++ b/desktop/startup.go
@@ -151,6 +151,24 @@ func (a *App) reloadFrontend(ctx context.Context) {
 	wailsRuntime.WindowReloadApp(ctx)
 }
 
+// DomReady is the Wails OnDomReady hook: it fires from the webview once the
+// document is ready, which is necessarily after Wails has finished setting up
+// the window on the platform UI loop.
+//
+// That ordering is the point. Every other reveal happens from the OnStartup
+// goroutine, which Wails launches *before* it finishes window setup — the
+// hidden-window race this app hit was exactly a window operation from that
+// goroutine being overtaken by a later one from the setup path. Creating the
+// window visible (main.go) is the fix; this hook is the guarantee, the one
+// reveal that can never be raced by window setup.
+//
+// It also fires again on every frontend reload (see reloadFrontend), which is
+// harmless: showWindow on a visible window is a no-op.
+func (a *App) DomReady(ctx context.Context) {
+	a.log().Debug("frontend DOM ready")
+	a.showWindow(ctx)
+}
+
 // Startup is called when the Wails app starts.
 func (a *App) Startup(ctx context.Context) {
 	// Catch any unrecovered panic during startup so a stack trace lands in

--- a/desktop/startup_phases.go
+++ b/desktop/startup_phases.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"github.com/v0lka/c0wrk/backend"
 	"github.com/v0lka/c0wrk/backend/config"
@@ -168,15 +167,13 @@ func (a *App) initTools(ctx context.Context, log *slog.Logger) (toolsBinPath str
 		},
 	})
 
-	// Show the window unconditionally at the start of tool initialization so
-	// the frontend has time to mount and subscribe to events before
-	// backend:ready fires in Phase 5. On first run this reveals the
-	// tool-install splash; on subsequent runs it prevents the race where
-	// backend:ready is emitted before the frontend subscribes, which would
-	// leave the app stuck on the spinner forever.
-	// WindowShow is idempotent — calling it again in emitBackendReady is a
-	// no-op when the window is already visible.
-	wailsRuntime.WindowShow(ctx)
+	// Show the window unconditionally at the start of tool initialization.
+	// The window is already visible — main.go creates it that way on purpose
+	// (see the StartHidden note there) — so this is a no-op in a normal start.
+	// It is kept as a safety net: a window hidden for any other reason must
+	// still be back before the tool-install splash and backend:ready need it.
+	// showWindow is idempotent; emitBackendReady calls it again harmlessly.
+	a.showWindow(ctx)
 
 	// Early detection: check which tools need installing BEFORE doing any work.
 	needed, needsErr := mgr.NeedsInstall()
@@ -957,20 +954,19 @@ func (a *App) buildFrontendAPI(
 // emitBackendReady fires the EventBackendReady event with cached projects
 // when available, falling back to a fresh ListProjects call. The signal tells
 // the frontend that all synchronous backend subsystems are wired up.
-// WindowShow is called unconditionally — when the window was already shown
-// for tool installation this is a no-op; when no tools were needed this is
-// the first time the window becomes visible.
+// showWindow is called unconditionally and is idempotent — the window is
+// created visible, so this is the last of several no-op safety nets rather
+// than the moment the window appears.
 //
 // filterNoProject strips the No Project pseudo-project from the emitted list
 // regardless of whether projects come from cache or a fresh query.
 // This is used when LLM is unconfigured to prevent the frontend from
 // auto-loading No Project before the settings dialog is shown.
 func (a *App) emitBackendReady(cachedProjects []project.ProjectInfo, projectMgr *project.Manager, filterNoProject bool, log *slog.Logger) {
-	// When the window is still hidden (no tools needed installing), show it now.
-	// WindowShow is idempotent: if already visible (tools were installed), it's a no-op.
+	// Last safety-net reveal before the frontend is told the backend is up.
 	// Guard against nil ctx in tests (no Wails lifecycle).
 	if a.ctx != nil {
-		wailsRuntime.WindowShow(a.ctx)
+		a.showWindow(a.ctx)
 	}
 
 	// Collect projects from cache or fresh query, applying No Project filter if

--- a/desktop/window_show_test.go
+++ b/desktop/window_show_test.go
@@ -1,0 +1,119 @@
+package desktop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/v0lka/c0wrk/backend"
+)
+
+// windowShowFixture wires an App with the window-reveal test hooks: a counting
+// stand-in for wailsRuntime.WindowShow (a.windowShowFn) and a captured event
+// sink (a.wailsEmit). Both take precedence over the production wailsRuntime
+// calls, which panic on a context that no live Wails runtime owns.
+type windowShowFixture struct {
+	app       *App
+	showCalls int
+	showCtxs  []context.Context
+	emitted   []string
+}
+
+func newWindowShowFixture() *windowShowFixture {
+	f := &windowShowFixture{}
+	f.app = NewApp()
+	f.app.ctx = context.Background()
+	f.app.windowShowFn = func(ctx context.Context) {
+		f.showCalls++
+		f.showCtxs = append(f.showCtxs, ctx)
+	}
+	f.app.wailsEmit = func(eventName string, _ ...any) {
+		f.emitted = append(f.emitted, eventName)
+	}
+	return f
+}
+
+// TestShowWindow_UsesSeamAndForwardsContext verifies showWindow prefers the
+// injected hook over wailsRuntime and hands it the caller's context unchanged.
+// Every reveal path depends on this delegation to stay testable.
+func TestShowWindow_UsesSeamAndForwardsContext(t *testing.T) {
+	f := newWindowShowFixture()
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	f.app.showWindow(ctx)
+
+	if f.showCalls != 1 {
+		t.Fatalf("expected exactly one window show, got %d", f.showCalls)
+	}
+	if got := f.showCtxs[0].Value(ctxKey{}); got != "marker" {
+		t.Errorf("expected the caller's context to be forwarded, got value %v", got)
+	}
+}
+
+// TestDomReady_ShowsWindow is the core regression guard for the hidden-window
+// race. OnDomReady is the one reveal that fires after Wails has finished
+// setting the window up, so it can never be overtaken by that setup — unlike
+// the reveals issued from the OnStartup goroutine. Losing this call would
+// remove the guarantee that a window hidden by window setup comes back.
+func TestDomReady_ShowsWindow(t *testing.T) {
+	f := newWindowShowFixture()
+
+	f.app.DomReady(context.Background())
+
+	if f.showCalls != 1 {
+		t.Fatalf("expected DomReady to request exactly one window show, got %d", f.showCalls)
+	}
+	if len(f.emitted) != 0 {
+		t.Errorf("expected DomReady to emit no events, got %v", f.emitted)
+	}
+}
+
+// TestDomReady_RepeatIsHarmless covers the reload path: reloadFrontend makes
+// the webview re-fire OnDomReady on an already-visible window. The repeat must
+// stay a plain idempotent reveal — no panic, no events, no extra state.
+func TestDomReady_RepeatIsHarmless(t *testing.T) {
+	f := newWindowShowFixture()
+
+	f.app.DomReady(context.Background())
+	f.app.DomReady(context.Background())
+	f.app.DomReady(context.Background())
+
+	if f.showCalls != 3 {
+		t.Fatalf("expected one window show per DomReady, got %d", f.showCalls)
+	}
+	if len(f.emitted) != 0 {
+		t.Errorf("expected no events from repeated DomReady, got %v", f.emitted)
+	}
+}
+
+// TestEmitBackendReady_ShowsWindow verifies the last startup-path safety net
+// still asks for the window before telling the frontend the backend is up.
+func TestEmitBackendReady_ShowsWindow(t *testing.T) {
+	f := newWindowShowFixture()
+
+	f.app.emitBackendReady(nil, nil, false, testLoggerForPhases())
+
+	if f.showCalls != 1 {
+		t.Fatalf("expected emitBackendReady to request one window show, got %d", f.showCalls)
+	}
+	if len(f.emitted) != 1 || f.emitted[0] != backend.EventBackendReady {
+		t.Errorf("expected one %s event, got %v", backend.EventBackendReady, f.emitted)
+	}
+}
+
+// TestEmitBackendReady_NilCtxSkipsShow guards the nil-ctx path used by tests
+// that run startup phases without a Wails lifecycle: no window call, but the
+// backend:ready signal must still reach the frontend.
+func TestEmitBackendReady_NilCtxSkipsShow(t *testing.T) {
+	f := newWindowShowFixture()
+	f.app.ctx = nil
+
+	f.app.emitBackendReady(nil, nil, false, testLoggerForPhases())
+
+	if f.showCalls != 0 {
+		t.Errorf("expected no window show with a nil ctx, got %d", f.showCalls)
+	}
+	if len(f.emitted) != 1 || f.emitted[0] != backend.EventBackendReady {
+		t.Errorf("expected one %s event, got %v", backend.EventBackendReady, f.emitted)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,15 @@ func mainImpl() int {
 		MinWidth:         1024,
 		MinHeight:        600,
 		BackgroundColour: options.NewRGB(40, 44, 52),
-		StartHidden:      os.Getenv("C0WRK_START_HIDDEN") != "false",
+		// The window is deliberately NOT created hidden. Wails applies
+		// StartHidden by queueing a hide on the platform UI loop *after* the
+		// webview starts loading, while OnStartup already runs concurrently on
+		// its own goroutine — so a fast backend start gets its WindowShow calls
+		// queued ahead of that hide, the hide executes last, and the window
+		// stays withdrawn for the life of the process. Starting visible removes
+		// the race: the window is mapped synchronously by Wails before its UI
+		// loop begins. Nothing is lost — desktop/startup_phases.go revealed the
+		// window unconditionally within a millisecond of startup anyway.
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
@@ -119,6 +127,7 @@ func mainImpl() int {
 			DisableWebViewDrop: true,
 		},
 		OnStartup:  app.Startup,
+		OnDomReady: app.DomReady,
 		OnShutdown: app.Shutdown,
 		// Close guard: every quit path (window close button, Cmd+Q / the OS
 		// quit menu, runtime.Quit — including the updater's quit) funnels

--- a/specs/architecture/data-flow.md
+++ b/specs/architecture/data-flow.md
@@ -142,14 +142,19 @@ desktop/startup.go (background goroutine, after EventBackendReady):
 
 ## Startup Sequence
 
-Application startup follows a phased approach. The window starts hidden (gated by the `C0WRK_START_HIDDEN` env var) and is revealed unconditionally during Phase 2 so the frontend mounts and subscribes to events before `backend:ready`:
+Application startup follows a phased approach. **The window is created visible — never with `StartHidden`.** Wails applies `StartHidden` by queueing a hide on the platform UI loop *after* the webview starts loading, while `OnStartup` already runs concurrently on its own goroutine. A fast backend start therefore gets its `WindowShow` calls queued ahead of that hide, the hide executes last, and the window stays withdrawn for the life of the process — a clean startup log and no window. Starting visible removes the race: Wails maps the window synchronously before its UI loop begins.
+
+The reveals below all remain, but as idempotent safety nets rather than the moment the window appears. `OnDomReady` is the one that carries a guarantee: it fires after window setup has finished, so unlike the reveals issued from the `OnStartup` goroutine it can never be overtaken by that setup.
 
 ```
 main.go:
   ├─ LoadWindowBounds(~/.c0wrk/window_state.json)
   │   └─ valid width/height + maximized state seed Wails options;
   │      missing/malformed/below-minimum dimensions use defaults
-  └─ wails.Run(options.App{StartHidden: os.Getenv("C0WRK_START_HIDDEN") != "false", ...})
+  └─ wails.Run(options.App{  // no StartHidden — see the race note above
+       OnStartup:  app.Startup,
+       OnDomReady: app.DomReady,   → showWindow() — post-window-setup guarantee
+       OnShutdown: app.Shutdown, ...})
   ↓
 Phase 0: resolve agent directory
 Phase 1: shell env + logger (<50ms)
@@ -157,8 +162,8 @@ Phase 2: config + tools (parallel, up to 3-10 min on first run)
   │
   ├─ config.ResolveAndLoad() — YAML parse + env expansion + defaults
   └─ initTools()
-      ├─ wailsRuntime.WindowShow(ctx) — window shown unconditionally so the
-      │   frontend mounts and subscribes to events before backend:ready
+      ├─ a.showWindow(ctx) — idempotent safety net; the window is already
+      │   visible, so this only matters if something else hid it
       ├─ Manager.NeedsInstall() — quick check (.versions + binary existence)
       ├─ if tools needed: emit tool_manager:start(tools)  → frontend shows splash
       ├─ EnsureCriticalTools(AllowNetwork:false)  (always runs; strictly local:
@@ -178,8 +183,8 @@ Phase 4: stores + preload (~100ms)
 Phase 5: application + frontend API (~150ms)
   ↓
 emitBackendReady():
-  ├─ WindowShow(ctx)  (idempotent no-op if already visible — window is shown
-  │   unconditionally in initTools, so this is always a no-op in practice)
+  ├─ showWindow(ctx)  (last idempotent safety net; the window is created
+  │   visible and initTools already re-showed it, so this is always a no-op)
   └─ emit backend:ready
 ```
 


### PR DESCRIPTION
## Symptom

`c0wrk-desktop` starts, logs a clean and complete startup, keeps running — and never shows a window. The X11 toplevel exists with a plausible geometry, but never gets a `WM_STATE`: it stays Withdrawn for the life of the process. `xdotool windowmap` on it does not stick.

Reported on Arch/KDE/X11 against v0.7.3 as intermittent. With an unconfigured or unparseable `config.yaml` it is not intermittent at all — it reproduced **5 of 5 runs**.

## Root cause

The window was created hidden (`StartHidden`) and revealed later by `runtime.WindowShow` calls issued from the backend startup goroutine.

The obvious reading — "the show fires before GTK realizes the toplevel and is dropped" — is wrong. Traced on a live failing run with gdb breakpoints on `gtk_widget_show` / `gtk_widget_hide`, the actual order was:

```
gtk_widget_show_all  0x…520   ← Wails, main thread, direct call
gtk_widget_show      0x…520   ← from show_all
gtk_widget_show      0x…520   ← WindowShow #1 (initTools)
gtk_widget_show      0x…520   ← WindowShow #2 (emitBackendReady)
gtk_widget_hide      0x…520   ← StartHidden's hide — runs LAST
gtk_widget_unmap     …        → Withdrawn
```

Both shows executed. Nothing was dropped, and the window was realized the whole time.

Wails queues `StartHidden`'s hide on the GTK idle loop from `Window.Run` — but only *after* `LoadIndex` (`webkit_web_view_load_uri`), which costs milliseconds — while `OnStartup` is already running on a goroutine Wails spawned earlier. Idle sources run in attach order:

```
main thread │ spawn goroutine ─┐  pack  LoadIndex(webkit ≈ ms)  g_idle_add(Hide)  show_all  gtk_main()
            │                  │                                        ▲
goroutine   │                  └─ Startup ─ initTools ─ g_idle_add(Show#1)   ~0.5 ms
            │                            └─ emitBackendReady ─ g_idle_add(Show#2)  ~5 ms
            │                                                            │
            │  idle queue:  [ Show#1 , Show#2 , Hide ]  ──────────────────┘
            │                                    ▲ last one wins
```

So the race is **backend startup against webkit's URI load**, not against GTK realizing the toplevel. `LoadShellEnvironment` is a no-op on Linux, so the goroutine reaches its first reveal in well under a millisecond. A broken config skips provider init and brings the whole backend start down to ~5 ms, which reliably beats webkit — hence deterministic rather than rare. A valid config makes startup slow enough that `Show#2` lands after the hide, and the window appears.

A retry loop or a wait-until-realized would have papered over this without fixing it.

## Fix

**Do not create the window hidden.** Wails then maps it synchronously on the main thread before its UI loop begins, and there is no hide left to lose to.

`StartHidden` bought nothing: `initTools` already revealed the window unconditionally within a millisecond of startup, so the hidden period was sub-millisecond by design. `C0WRK_START_HIDDEN` goes with it — a switch whose only effect is to re-enable a broken state is worse than no switch.

Additionally:

- **`OnDomReady` as a guaranteed reveal.** It fires after Wails has finished window setup, so unlike the reveals issued from the `OnStartup` goroutine it can never be overtaken by that setup. A no-op in a normal start; harmless on the reload path where it fires again.
- **One reveal path.** Both startup phases, `OnDomReady` and the close guard now go through `App.showWindow`, which honours the existing `windowShowFn` test seam. `wailsRuntime.WindowShow` is called from exactly one place.

`DomReady` takes a `context.Context`, so — like `Startup` and `Shutdown` — Wails does not bind it. No new frontend RPC surface; generated bindings are unchanged.

## Verification

Against the same broken `config.yaml` that reproduced the bug 5/5, on Arch/KDE/X11:

| | before | after |
|---|---|---|
| `WM_STATE: Normal` | 0/5 | **5/5** |
| `gtk_widget_hide` on toplevel | yes | **none** (4 shows, no hide) |
| GDK/GTK assertions from startup | none¹ | none |

¹ See "Not in scope" below.

- New unit tests in `desktop/window_show_test.go` cover the reveal on `DomReady` (incl. the repeated reload case) and on `emitBackendReady` (incl. the nil-ctx path), plus context forwarding through the seam. Mutation-checked: removing the `showWindow` call from either site fails three tests.
- `gofmt`, `go vet`, `go build ./...`, `go test ./desktop` clean.
- `go test ./...` has one pre-existing unrelated failure: `TestCheckoutBranch_LocalChangesOverwritten` asserts on English text from a localized `git`. It fails on a clean checkout of `main` too and passes under `LC_ALL=C`.

## Not in scope

- **The GDK/GTK assertions quoted in the bug report are from shutdown, not startup.** They follow `Shutting down…` in `stderr.log` and never appear during startup; the failing run had none at start. Source is `saveWindowBounds` reading geometry off an already-torn-down window. Separate issue, untouched here.
- **The Arch packaging workaround stays for now.** `c0wrk-bin` builds from the v0.7.3 release tag and `c0wrk-git` from the default branch, so the `C0WRK_START_HIDDEN=false` launcher is dropped only once this ships in a release.

## Review notes

The change is platform-neutral — no new platform branches — but I could only verify on Linux/X11. For reference, on the other two backends `StartHidden` behaves differently and neither should regress from removing it:

- **Windows**: handled in `navigationCompleted`, where `StartHidden` merely *skips* `ShowWindow` rather than hiding an already-shown window.
- **macOS**: passed into `Create()`, so the window is simply built visible instead.

A sanity check on either platform before merge would be welcome.
