### PR TITLE
build(make): make dev-desktop launch the desktop app, not just Vite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ Use the Makefile; it handles platform-specific ONNX Runtime bootstrap across the
 - `make vulncheck` — Go dependency vulnerability gate (`govulncheck`, version pinned in the Makefile). Fails when a vulnerability from the official Go vulnerability database is reachable from this module's code. The CI `security` job runs the exact same command. **Mandatory before every PR** — a stale Go toolchain (go.mod below the latest security patch) fails this gate even when lint and test are clean. On Windows (no make): `go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...`
 - `make fmt-check` — fails when `gofmt -l` reports any Go file under the root package, `internal/`, `core/`, `backend/`, or `desktop/`
 - `make build` — installs frontend deps, runs `wails build` with version ldflags, then `make fetch-onnx` + `make fetch-embedding-model`
-- `make dev-desktop` — Vite dev server only (`cd frontend && npm run dev`); for full hot-reload use `wails dev` from repo root
+- `make dev-desktop` — full desktop hot-reload loop (`wails dev` with the platform build tags; on Linux `-tags webkit2_41` is mandatory or the cgo build fails against webkit2gtk-4.0 and `wails dev` hangs without a window)
+- `make dev-frontend` — Vite dev server only (`cd frontend && npm run dev`); no Go bridge, so the UI stays on the startup splash
 - `make fetch-onnx` — downloads ONNX Runtime 1.28.1 into `.cache/` and copies it into the platform build output. **Required after every direct `wails build`** or the app won't launch.
 - `make bump` — resolves the latest `github.com/v0lka/sp4rk` remote commit and updates the module with `GOWORK=off`; use only at the release point of a cross-repo development cycle
 - `make clean` — removes `build/bin`, `.cache`, `frontend/dist`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,8 @@ make frontend-deps   # npm install in frontend/
 make test            # go test ./... && cd frontend && npm test (vitest)
 make fmt-check       # fail if gofmt would rewrite any Go source
 make lint            # make fmt-check + golangci-lint + frontend ESLint
-make dev-desktop     # frontend Vite dev server only
+make dev-desktop     # full desktop hot-reload loop (wails dev + platform tags)
+make dev-frontend    # frontend Vite dev server only (no Go bridge)
 make build           # versioned wails build + ONNX runtime + embedding model
 make bump            # update the pinned sp4rk revision with GOWORK=off (release point only)
 make clean           # remove build/bin, .cache, frontend/dist
@@ -180,16 +181,23 @@ Frontend tests use **vitest** (`npm test` / `npm run test:watch`); test files li
 
 ### Development
 
-Frontend-only development server:
+Full desktop hot-reload workflow — builds and runs the app with the live
+frontend dev server attached:
 
 ```bash
 make dev-desktop
 ```
 
-Full desktop hot-reload workflow (from repo root):
+On Linux this passes `-tags webkit2_41`. Invoking `wails dev` directly without
+that tag fails the cgo build against `webkit2gtk-4.0` (absent on Ubuntu 24.04+
+and Arch) — and `wails dev` does not exit on that failure, so it looks like it
+is running while no window ever appears.
+
+Frontend-only development server (markup and HMR work; no Go bridge, so the UI
+stays on the startup splash):
 
 ```bash
-wails dev
+make dev-frontend
 ```
 
 ### Production build
@@ -238,7 +246,8 @@ Vector index needs ONNX Runtime plus a quantized embedding model + tokenizer (fe
 - **Config not detected**: ensure the file is exactly at `~/.c0wrk/config.yaml`.
 - **App fails after build due to missing ONNX library**: run `make fetch-onnx`.
 - **Missing embedding model files**: run `make fetch-embedding-model`.
-- **`make dev-desktop` shows only frontend**: this command runs Vite only; use `wails dev` for the full desktop runtime loop.
+- **`make dev-frontend` shows only the splash screen**: expected — it runs Vite alone, with no Wails runtime behind it. Use `make dev-desktop` for the full desktop loop.
+- **`wails dev` prints `Package 'webkit2gtk-4.0' not found` and never opens a window**: pass the Linux build tag (`wails dev -tags webkit2_41`), or just use `make dev-desktop`, which applies it for you. The command deliberately keeps running after a failed build, so the missing window is the only symptom.
 - **Generated Wails bindings drift** (`frontend/wailsjs/go/desktop/App.*`): regenerate via `wails build` or `wails dev` (do not hand-edit generated files).
 
 ## Continuous integration

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test bench-startup lint fmt-check vulncheck dev-desktop bump fetch-onnx fetch-embedding-model clean-onnx clean frontend-deps
+.PHONY: build test bench-startup lint fmt-check vulncheck dev-desktop dev-frontend bump fetch-onnx fetch-embedding-model clean-onnx clean frontend-deps
 
 # govulncheck version pinned for reproducible vulnerability scans (CI runs the
 # same `make vulncheck` command; upgrade deliberately, both repos in lockstep).
@@ -189,7 +189,20 @@ fmt-check:
 		exit 1; \
 	fi
 
+# Full desktop hot-reload loop: builds and runs the Wails app with the live
+# frontend dev server attached. WAILS_TAGS is required on Linux — without
+# `-tags webkit2_41` the cgo build fails against webkit2gtk-4.0 (absent on
+# Ubuntu 24.04+ and Arch) and `wails dev` does NOT exit: it prints the build
+# error, keeps the Vite watcher alive and waits for a file change, so the
+# session looks healthy while no window ever appears.
 dev-desktop:
+	wails dev $(WAILS_TAGS)
+
+# Frontend-only Vite server. No Go, no window: `window.runtime`/`window.go`
+# are absent, so the UI stays on the startup splash (backend:ready never
+# arrives and the listProjects safety-net RPC throws into a silent catch).
+# Useful for markup and HMR work, not for anything that calls into Go.
+dev-frontend:
 	cd frontend && npm run dev
 
 # Download and extract ONNX Runtime library next to the executable.


### PR DESCRIPTION
# build(make): make `dev-desktop` actually launch the desktop app

## Why

`make dev-desktop` never launched the desktop app. The target was, verbatim:

```make
dev-desktop:
	cd frontend && npm run dev
```

`npm run dev` is `vite` — so the target started **only the frontend dev
server**. No Go build, no Wails runtime, no window. `git log -L` shows it has
been this way since the Makefile's first commit (`07187576`), so this is not a
regression, but the name has promised a desktop app the whole time.

### What you actually get from the Vite-only server

The UI loads at `http://localhost:5173` and then sits on the startup splash
forever. In a plain browser there is no `window.runtime` and no `window.go`,
and the entire bridge to Go goes through them (`frontend/src/api/runtime.ts`):

- `window.go.desktop.App.*` — `getApp()` throws `Wails App bindings are not available`
- `window.runtime.EventsOn` — `subscribe()` degrades to a no-op unsubscribe

`App.tsx` starts in the `splash` phase and has exactly two ways out, both of
which are closed in the browser:

1. `subscribe('backend:ready')` → the subscription is a no-op, so the event
   never arrives.
2. The mount-time `listProjects()` safety net (`App.tsx:159`) → `getApp()`
   throws and the rejection is swallowed by a deliberately silent `.catch()`
   (in the real app that catch covers an expected startup race).

So the target is usable for markup and HMR work, and for nothing that calls
into Go.

### The sharper problem: the Linux build tag

The documented alternative was "use `wails dev`". On Ubuntu 24.04+ and Arch
that fails: Wails v2 links against `webkit2gtk-4.0` by default, and only
`4.1` is present.

```
Package 'webkit2gtk-4.0' not found
Build error - exit status 1
```

The trap is that **`wails dev` does not exit on this failure**. It prints
`No version running, build will be retriggered as soon as changes have been
detected`, keeps the Vite watcher alive and waits for a file change. The
session looks perfectly healthy — the only symptom is that no window ever
appears.

The Makefile already computes the right tag for Linux:

```make
ifeq ($(UNAME_S),Linux)
	WAILS_TAGS := -tags webkit2_41
else
	WAILS_TAGS :=
endif
```

…but only the `build` target used it. Neither the Makefile nor the docs
mentioned the tag anywhere in a development context.

Worth knowing while debugging this: a plain `go build` (no Wails tags)
**succeeds** and produces a non-functional stub that exits at startup with
`Wails applications will not build without the correct build tags.` So "it
compiled" proves nothing here — `wails build` / `wails dev` inject the
`desktop`/`production` tags themselves.

## What changes

- `make dev-desktop` now runs `wails dev $(WAILS_TAGS)` — the full desktop
  hot-reload loop, with the Linux build tag applied automatically.
- `make dev-frontend` is added, carrying the old behaviour
  (`cd frontend && npm run dev`) under a name that describes it.
- `.PHONY` updated; both targets carry comments explaining the failure modes
  above, so the next person does not have to rediscover them.

Docs updated to match:

- `AGENTS.md` — command list.
- `CONTRIBUTING.md` — command list, the *Development* section, and two
  troubleshooting entries (the splash-only frontend server, and the silent
  `wails dev` build failure on Linux).

`core/prompts/commit_message.md` mentions `make dev-desktop` inside an
illustrative example diff. Left untouched: the target still exists, so the
example stays valid.

## Migration

Anyone who relied on `make dev-desktop` for the Vite-only server should switch
to `make dev-frontend`. No other target changes behaviour.

## Verification

- `make -n dev-desktop` → `wails dev -tags webkit2_41`
- `make -n dev-frontend` → `cd frontend && npm run dev`
- The tag itself is confirmed on Arch (webkit2gtk-4.1): `wails build -tags
  webkit2_41` compiles and the resulting binary opens a working window, while
  an untagged `wails dev` fails at exactly that cgo step. Same compile step,
  same tag — which is what this change supplies.

A full `make dev-desktop` run has **not** been executed on this machine: it
would start a second app instance against the live `~/.c0wrk/database.db`
while the installed app is running. Worth one manual run by the reviewer.

Documentation and Makefile only — no Go or TypeScript source is touched, so
lint/test results are unaffected.
