### PR TITLE
feat(ui): app-wide UI scale setting (50–200%) with zoom compensation

### DIFF
--- a/frontend/src/components/settings/SettingsModal.tsx
+++ b/frontend/src/components/settings/SettingsModal.tsx
@@ -9,6 +9,7 @@ import { useSettingsStore } from '@/stores/settingsStore'
 import { ConfigWarningBanner } from './ConfigWarningBanner'
 import { LogLevelSelector } from './LogLevelSelector'
 import { ThemeSelector } from './ThemeSelector'
+import { UIScaleSelector } from './UIScaleSelector'
 import { ProxySettings } from './ProxySettings'
 import { SoundSettings } from './SoundSettings'
 import { SessionStatsSettings } from './SessionStatsSettings'
@@ -186,6 +187,7 @@ export function SettingsModal() {
           <TabsContent value="general" className="mt-4 overflow-y-auto min-h-0 custom-scrollbar">
             <div className="space-y-6">
               <ThemeSelector />
+              <UIScaleSelector />
               <LogLevelSelector />
               <div className="border-t border-border pt-4">
                 <SoundSettings />

--- a/frontend/src/components/settings/UIScaleSelector.test.tsx
+++ b/frontend/src/components/settings/UIScaleSelector.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { UIScaleSelector } from './UIScaleSelector'
+import { useUiScaleStore } from '@/stores/uiScaleStore'
+
+// jsdom in this environment does not expose `window.localStorage`, which
+// zustand's persist middleware captures at store-creation time (see
+// uiScaleStore.test.ts). Installed before any store module import.
+vi.hoisted(() => {
+  const g = globalThis as Record<string, unknown>
+  const win = (g.window as Record<string, unknown> | undefined) ?? g
+  const map = new Map<string, string>()
+  win.localStorage = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v) },
+    removeItem: (k: string) => { map.delete(k) },
+    clear: () => map.clear(),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    get length() { return map.size },
+  }
+})
+
+// Radix popper positioning (autoUpdate) observes trigger/content with
+// ResizeObserver, which jsdom does not provide.
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  },
+)
+
+const PRESETS = [70, 80, 90, 100, 110, 125, 150, 175, 200]
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  // Reset the store to defaults between tests; nothing is persisted yet.
+  useUiScaleStore.setState({ scale: 100 })
+  localStorage.clear()
+  document.documentElement.style.zoom = ''
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+function scaleInput(): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>('input[aria-label="UI scale"]')
+  expect(el).not.toBeNull()
+  return el!
+}
+
+function chevron(): HTMLButtonElement {
+  const el = container.querySelector<HTMLButtonElement>('button[aria-label="UI scale presets"]')
+  expect(el).not.toBeNull()
+  return el!
+}
+
+/** Radix's DropdownMenuTrigger toggles on `pointerdown`, not `click`. */
+async function openDropdown(): Promise<void> {
+  const btn = chevron()
+  await act(async () => {
+    btn.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }))
+    await new Promise((r) => setTimeout(r, 10))
+  })
+}
+
+function menu(): HTMLDivElement {
+  const el = document.body.querySelector('[role="menu"]')
+  expect(el).not.toBeNull()
+  return el as HTMLDivElement
+}
+
+function menuItem(label: string): HTMLElement {
+  const option = Array.from(menu().querySelectorAll<HTMLElement>('[role="menuitem"]')).find((o) =>
+    o.textContent?.includes(label),
+  )
+  if (!option) throw new Error(`Menu item "${label}" not found`)
+  return option
+}
+
+describe('UIScaleSelector render', () => {
+  it('renders the UI Scale label and the current value with a % suffix', () => {
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    expect(container.textContent).toContain('UI Scale')
+    expect(scaleInput().value).toBe('100')
+    expect(container.textContent).toContain('%')
+  })
+
+  it('reflects a non-default store value', () => {
+    useUiScaleStore.setState({ scale: 150 })
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    expect(scaleInput().value).toBe('150')
+  })
+})
+
+describe('UIScaleSelector presets', () => {
+  it('offers the nine presets with the active one marked', async () => {
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    await openDropdown()
+    for (const p of PRESETS) {
+      expect(menu().textContent).toContain(String(p))
+    }
+    const selected = menu().querySelector<HTMLElement>('[data-selected="true"]')
+    expect(selected).not.toBeNull()
+    expect(selected!.textContent).toContain('100')
+  })
+
+  it('picking a preset updates the store scale and the zoom on <html> immediately', async () => {
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    await openDropdown()
+    act(() => {
+      menuItem('150').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // setScale applies the CSS zoom synchronously — no save step.
+    expect(useUiScaleStore.getState().scale).toBe(150)
+    expect(document.documentElement.style.zoom).toBe('1.5')
+    expect(scaleInput().value).toBe('150')
+  })
+
+  it('re-picking the current preset is a no-op (zoom untouched)', async () => {
+    useUiScaleStore.setState({ scale: 100 })
+    document.documentElement.style.zoom = '1'
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    await openDropdown()
+    act(() => {
+      menuItem('100').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(useUiScaleStore.getState().scale).toBe(100)
+    expect(document.documentElement.style.zoom).toBe('1')
+  })
+})
+
+describe('UIScaleSelector manual input', () => {
+  /** Set the input value the way a real browser does (React 19 controlled input):
+   *  native prototype setter + `input` event, so the synthetic onChange fires. */
+  function type(text: string): void {
+    const el = scaleInput()
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    if (!setter) throw new Error('native input setter not found')
+    act(() => {
+      setter.call(el, text)
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  function press(key: string): void {
+    act(() => {
+      scaleInput().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+    })
+  }
+
+  it('commits a manual value on Enter, applying the zoom immediately', () => {
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    type('125')
+    press('Enter')
+    expect(useUiScaleStore.getState().scale).toBe(125)
+    expect(document.documentElement.style.zoom).toBe('1.25')
+    expect(scaleInput().value).toBe('125')
+  })
+
+  it('clamps manual input to the supported bounds', () => {
+    act(() => {
+      root.render(<UIScaleSelector />)
+    })
+    type('999')
+    press('Enter')
+    expect(useUiScaleStore.getState().scale).toBe(200)
+    expect(document.documentElement.style.zoom).toBe('2')
+    expect(scaleInput().value).toBe('200')
+  })
+})

--- a/frontend/src/components/settings/UIScaleSelector.tsx
+++ b/frontend/src/components/settings/UIScaleSelector.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from 'react'
+import { EditableCombobox } from '@/components/ui/EditableCombobox'
+import { useUiScaleStore, UI_SCALE_MIN, UI_SCALE_MAX } from '@/stores/uiScaleStore'
+
+/** Preset scale choices offered in the dropdown, in percent. */
+const UI_SCALE_PRESETS = [70, 80, 90, 100, 110, 125, 150, 175, 200] as const
+
+/**
+ * General-tab "UI Scale" block: label + EditableCombobox over the persisted
+ * uiScaleStore. Presets cover the common zoom steps; manual input is clamped
+ * to [UI_SCALE_MIN, UI_SCALE_MAX] by the combobox and normalized again by the
+ * store. onChange maps straight to setScale, which applies the CSS zoom to
+ * <html> immediately — there is no apply/save step.
+ */
+export function UIScaleSelector() {
+  const scale = useUiScaleStore((s) => s.scale)
+  const setScale = useUiScaleStore((s) => s.setScale)
+
+  const handleScaleChange = useCallback(
+    (next: number) => {
+      setScale(next)
+    },
+    [setScale],
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">UI Scale</span>
+      </div>
+      <EditableCombobox
+        value={scale}
+        presets={UI_SCALE_PRESETS}
+        min={UI_SCALE_MIN}
+        max={UI_SCALE_MAX}
+        unit="%"
+        onChange={handleScaleChange}
+        ariaLabel="UI scale"
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/terminal/Terminal.tsx
+++ b/frontend/src/components/terminal/Terminal.tsx
@@ -6,6 +6,7 @@ import { useTerminalEvents } from '@/hooks/events/useTerminalEvents'
 import { useXTermTheme } from '@/hooks/useXTermTheme'
 import { useInputModeStore } from '@/stores/inputModeStore'
 import { useThemeStore } from '@/stores/themeStore'
+import { useUiScaleStore } from '@/stores/uiScaleStore'
 import { logger } from '@/lib/logger'
 
 interface TerminalProps {
@@ -193,6 +194,49 @@ export function Terminal({ sessionId, visible, isActive, onReady }: TerminalProp
             termRef.current.options.theme = theme
         }
     }, [theme])
+
+    // Re-fit when the app-wide UI scale (CSS zoom on <html>) changes: zoom
+    // resizes the container's layout box, which the container's own
+    // ResizeObserver already reports — but the renderer's char measurement
+    // and the canvas refresh can lag the style application by a frame.
+    // Scheduling the fit on the next animation frame (with a timeout-0
+    // fallback for environments without rAF, e.g. tests) lets the zoomed
+    // layout settle first, preventing a stale rows/cols fit and the
+    // "terminal larger than its box" overflow the stale fit causes.
+    const uiScale = useUiScaleStore((s) => s.scale)
+    const fitScheduledRef = useRef(false)
+    useEffect(() => {
+        const scheduleFit = () => {
+            if (fitScheduledRef.current) return
+            fitScheduledRef.current = true
+            const runFit = () => {
+                fitScheduledRef.current = false
+                const fitAddon = fitAddonRef.current
+                const term = termRef.current
+                if (!fitAddon || !term) return
+                try {
+                    fitAddon.fit()
+                    const { cols, rows } = term
+                    if (cols > 0 && rows > 0) {
+                        terminalResize(sessionId, cols, rows).catch((err) => {
+                            logger.error('Terminal resize error:', err)
+                        })
+                    }
+                } catch {
+                    // FitAddon can throw if terminal is not fully initialized
+                }
+            }
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(runFit)
+            } else {
+                setTimeout(runFit, 0)
+            }
+        }
+        scheduleFit()
+        return () => {
+            fitScheduledRef.current = false
+        }
+    }, [uiScale, sessionId])
 
     // Watch for "Open in Terminal" requests from the file-tree context menu
     // that arrive after the terminal is already running. The initial mount

--- a/frontend/src/components/ui/EditableCombobox.test.tsx
+++ b/frontend/src/components/ui/EditableCombobox.test.tsx
@@ -1,0 +1,297 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { EditableCombobox } from './EditableCombobox'
+
+// Radix popper positioning (autoUpdate) observes the trigger/content with
+// ResizeObserver, which jsdom does not provide.
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  },
+)
+
+const PRESETS = [75, 100, 125, 150] as const
+
+let container: HTMLDivElement
+let root: Root
+let onChange: ReturnType<typeof vi.fn<(n: number) => void>>
+
+beforeEach(() => {
+  onChange = vi.fn()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+type Props = Partial<Parameters<typeof EditableCombobox>[0]>
+
+function render(props: Props = {}) {
+  act(() => {
+    root.render(
+      <EditableCombobox
+        ariaLabel="UI scale"
+        value={100}
+        presets={PRESETS}
+        min={50}
+        max={200}
+        unit="%"
+        onChange={onChange}
+        {...props}
+      />,
+    )
+  })
+}
+
+function input(): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>('input[aria-label="UI scale"]')
+  expect(el).not.toBeNull()
+  return el!
+}
+
+function chevron(): HTMLButtonElement {
+  const el = container.querySelector<HTMLButtonElement>('button[aria-label="UI scale presets"]')
+  expect(el).not.toBeNull()
+  return el!
+}
+
+/** Set the input value the way a real browser does (React 19 controlled input):
+ *  native prototype setter + `input` event, so the synthetic onChange fires. */
+function type(text: string): void {
+  const el = input()
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+  if (!setter) throw new Error('native input setter not found')
+  act(() => {
+    setter.call(el, text)
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+/** React 17+ delegates onBlur via the native `focusout` event. */
+async function blur(): Promise<void> {
+  await act(async () => {
+    input().dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function press(key: string, alt = false): void {
+  act(() => {
+    input().dispatchEvent(new KeyboardEvent('keydown', { key, altKey: alt, bubbles: true }))
+  })
+}
+
+/** Radix's DropdownMenuTrigger toggles on `pointerdown`, not `click`. */
+async function openDropdown(): Promise<void> {
+  const btn = chevron()
+  await act(async () => {
+    btn.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }))
+    await new Promise((r) => setTimeout(r, 10))
+  })
+}
+
+function menu(): HTMLDivElement {
+  const el = document.body.querySelector('[role="menu"]')
+  expect(el).not.toBeNull()
+  return el as HTMLDivElement
+}
+
+function menuItem(label: string): HTMLElement {
+  const option = Array.from(menu().querySelectorAll<HTMLElement>('[role="menuitem"]')).find((o) =>
+    o.textContent?.includes(label),
+  )
+  if (!option) throw new Error(`Menu item "${label}" not found`)
+  return option
+}
+
+describe('EditableCombobox render', () => {
+  it('shows the value and the unit suffix', () => {
+    render()
+    expect(input().value).toBe('100')
+    expect(container.textContent).toContain('%')
+  })
+
+  it('renders without a unit', () => {
+    render({ unit: undefined })
+    expect(input().value).toBe('100')
+  })
+})
+
+describe('EditableCombobox manual input', () => {
+  it('commits a valid value on Enter', () => {
+    render()
+    type('133')
+    press('Enter')
+    expect(onChange).toHaveBeenCalledWith(133)
+    expect(input().value).toBe('133')
+  })
+
+  it('commits a valid value on blur', async () => {
+    render()
+    type('160')
+    await blur()
+    expect(onChange).toHaveBeenCalledWith(160)
+  })
+
+  it('clamps a below-min value to min on Enter', () => {
+    render()
+    type('30')
+    press('Enter')
+    expect(onChange).toHaveBeenCalledWith(50)
+    expect(input().value).toBe('50')
+  })
+
+  it('clamps an above-max value to max on blur', async () => {
+    render()
+    type('999')
+    await blur()
+    expect(onChange).toHaveBeenCalledWith(200)
+    expect(input().value).toBe('200')
+  })
+
+  it('reverts non-numeric input on Enter without onChange', () => {
+    render()
+    type('abc')
+    press('Enter')
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input().value).toBe('100')
+  })
+
+  it('reverts empty input on blur without onChange', async () => {
+    render()
+    type('')
+    await blur()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input().value).toBe('100')
+  })
+
+  it('Escape discards the edit without onChange', () => {
+    render()
+    type('180')
+    press('Escape')
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input().value).toBe('100')
+  })
+})
+
+describe('EditableCombobox dropdown', () => {
+  it('opens via the chevron and renders every preset with the active one checked', async () => {
+    render()
+    await openDropdown()
+    for (const p of PRESETS) {
+      expect(menu().textContent).toContain(String(p))
+    }
+    const selected = menu().querySelector<HTMLElement>('[data-selected="true"]')
+    expect(selected).not.toBeNull()
+    expect(selected!.textContent).toContain('100')
+    // The check mark is the CheckIcon svg inside the selected item.
+    expect(selected!.querySelector('svg')).not.toBeNull()
+  })
+
+  it('opens via ArrowDown and Alt+ArrowDown from the input', () => {
+    render()
+    press('ArrowDown')
+    expect(document.body.querySelector('[role="menu"]')).not.toBeNull()
+    act(() => {
+      menu().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(document.body.querySelector('[role="menu"]')).toBeNull()
+    press('ArrowDown', true)
+    expect(document.body.querySelector('[role="menu"]')).not.toBeNull()
+  })
+
+  it('clicking a preset commits it via onChange and closes the menu', async () => {
+    render()
+    await openDropdown()
+    act(() => {
+      menuItem('150').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onChange).toHaveBeenCalledWith(150)
+    expect(input().value).toBe('150')
+    expect(document.body.querySelector('[role="menu"]')).toBeNull()
+  })
+
+  it('re-picking the current preset is a no-op (no onChange)', async () => {
+    render()
+    await openDropdown()
+    act(() => {
+      menuItem('100').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(document.body.querySelector('[role="menu"]')).toBeNull()
+  })
+})
+
+describe('EditableCombobox inside a modal Radix dialog', () => {
+  function renderInDialog() {
+    act(() => {
+      root.render(
+        <Dialog open onOpenChange={() => {}}>
+          <DialogContent>
+            <DialogTitle>Settings</DialogTitle>
+            <DialogDescription>Test harness dialog</DialogDescription>
+            <EditableCombobox
+              ariaLabel="UI scale"
+              value={100}
+              presets={PRESETS}
+              min={50}
+              max={200}
+              unit="%"
+              onChange={onChange}
+            />
+          </DialogContent>
+        </Dialog>,
+      )
+    })
+    const dialogContent = document.body.querySelector('[data-slot="dialog-content"]')
+    expect(dialogContent).not.toBeNull()
+  }
+
+  it('commits manual input from inside the dialog', () => {
+    renderInDialog()
+    const el = document.body.querySelector<HTMLInputElement>('input[aria-label="UI scale"]')
+    expect(el).not.toBeNull()
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    act(() => {
+      setter!.call(el!, '133')
+      el!.dispatchEvent(new Event('input', { bubbles: true }))
+      el!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(onChange).toHaveBeenCalledWith(133)
+  })
+
+  it('selects a preset without dismissing the dialog', async () => {
+    renderInDialog()
+    const btn = document.body.querySelector<HTMLButtonElement>(
+      'button[aria-label="UI scale presets"]',
+    )
+    expect(btn).not.toBeNull()
+    await act(async () => {
+      btn!.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }))
+      await new Promise((r) => setTimeout(r, 10))
+    })
+    // The modal dialog locks body pointer events; the menu layer must
+    // re-enable them for itself (Radix DismissableLayer).
+    expect(menu().style.pointerEvents).toBe('auto')
+    act(() => {
+      menuItem('125').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onChange).toHaveBeenCalledWith(125)
+    expect(document.body.querySelector('[data-slot="dialog-content"]')).not.toBeNull()
+  })
+})

--- a/frontend/src/components/ui/EditableCombobox.tsx
+++ b/frontend/src/components/ui/EditableCombobox.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { CheckIcon, ChevronDownIcon } from 'lucide-react'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+
+interface EditableComboboxProps {
+  /** Current numeric value (percent, tokens, …). */
+  value: number
+  /** Preset choices offered in the dropdown. */
+  presets: readonly number[]
+  /** Inclusive bounds applied on commit (Enter / blur / preset pick). */
+  min: number
+  max: number
+  /** Suffix rendered next to the number (e.g. "%"). */
+  unit?: string
+  onChange: (n: number) => void
+  /** Accessible name for the text input and the chevron button. */
+  ariaLabel: string
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * EditableCombobox — a numeric input with a preset dropdown for settings
+ * forms, built on the project's Radix `dropdown-menu` primitives (works
+ * inside modal Radix dialogs for the same reasons as `Combobox`).
+ *
+ * The text field is the primary input; the chevron button (or ArrowDown /
+ * Alt+ArrowDown) opens a Radix DropdownMenu of presets. Local text state
+ * mirrors `value` until the user types; commits happen on Enter, blur or
+ * preset pick with `parseInt` semantics: NaN or empty reverts to the last
+ * valid value (no onChange), out-of-range values are clamped to [min, max].
+ * Escape reverts the pending edit without committing.
+ */
+export function EditableCombobox({
+  value,
+  presets,
+  min,
+  max,
+  unit,
+  onChange,
+  ariaLabel,
+  disabled = false,
+  className,
+}: EditableComboboxProps) {
+  const [text, setText] = useState(String(value))
+  const [open, setOpen] = useState(false)
+  const lastValid = useRef(value)
+
+  // Keep the field in sync when the controlled value changes externally
+  // (preset picked elsewhere, settings reloaded, …).
+  useEffect(() => {
+    setText(String(value))
+    lastValid.current = value
+  }, [value])
+
+  /** Parse + clamp + commit; NaN/empty reverts to the last valid value. */
+  const commit = (raw: string): void => {
+    const parsed = parseInt(raw, 10)
+    if (Number.isNaN(parsed)) {
+      setText(String(lastValid.current))
+      return
+    }
+    const clamped = Math.min(Math.max(parsed, min), max)
+    setText(String(clamped))
+    lastValid.current = clamped
+    if (clamped !== value) onChange(clamped)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      commit(text)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setText(String(lastValid.current))
+    } else if (e.key === 'ArrowDown') {
+      // ArrowDown opens the preset menu (ARIA combobox convention); Alt is
+      // accepted too. The caret jump it would cause in a single-line numeric
+      // field is not meaningful.
+      e.preventDefault()
+      setOpen(true)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'c0-input flex h-8 w-full min-w-0 items-center gap-1 rounded-md border border-input px-2 text-sm',
+        'focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/30',
+        'has-disabled:cursor-not-allowed has-disabled:opacity-50',
+        className,
+      )}
+    >
+      <input
+        type="text"
+        inputMode="numeric"
+        aria-label={ariaLabel}
+        disabled={disabled}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={() => commit(text)}
+        className="h-full w-full min-w-0 flex-1 bg-transparent text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50"
+      />
+      {unit && (
+        <span className="pointer-events-none shrink-0 select-none text-xs text-muted-foreground">
+          {unit}
+        </span>
+      )}
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild disabled={disabled}>
+          <button
+            type="button"
+            aria-label={`${ariaLabel} presets`}
+            disabled={disabled}
+            title={`${ariaLabel} presets`}
+            className="flex size-6 shrink-0 cursor-default items-center justify-center rounded-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+          >
+            <ChevronDownIcon className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent aria-label={`${ariaLabel} presets`} align="end">
+          {presets.map((p) => {
+            const isSelected = p === value
+            return (
+              <DropdownMenuItem
+                key={p}
+                data-selected={isSelected}
+                className={cn('gap-2 px-3 py-1.5 text-xs', isSelected && 'bg-primary/10 font-medium')}
+                onSelect={() => {
+                  setText(String(p))
+                  lastValid.current = p
+                  if (p !== value) onChange(p)
+                }}
+              >
+                <span className="flex-1 text-left">
+                  {p}
+                  {unit ? ` ${unit}` : ''}
+                </span>
+                {isSelected && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
+              </DropdownMenuItem>
+            )
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useResize.test.ts
+++ b/frontend/src/hooks/useResize.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { MouseEvent as ReactMouseEvent } from 'react'
+
+// jsdom in this environment does not expose `window.localStorage`, which
+// zustand's persist middleware captures at store-creation time. Install an
+// in-memory polyfill before any store module is imported (same pattern as
+// themeStore.test.ts) so uiScaleStore — imported by useResize — works.
+vi.hoisted(() => {
+  const g = globalThis as Record<string, unknown>
+  const win = (g.window as Record<string, unknown> | undefined) ?? g
+  const map = new Map<string, string>()
+  win.localStorage = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v) },
+    removeItem: (k: string) => { map.delete(k) },
+    clear: () => map.clear(),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    get length() { return map.size },
+  }
+})
+
+import { useResize, pointerDeltaToLayout } from './useResize'
+import { useUiScaleStore } from '@/stores/uiScaleStore'
+
+/**
+ * The "glued divider" acceptance criterion, encoded as a property: under a
+ * UI zoom of `scale`%, a pointer drag of `visualDelta` on-screen pixels must
+ * produce a layout-pixel width change of visualDelta / (scale/100) — so the
+ * rendered (zoomed) width change equals the pointer movement exactly and the
+ * divider stays under the cursor.
+ */
+function expectGlued(visualDelta: number, scalePercent: number, startWidth: number): number {
+  const layoutDelta = pointerDeltaToLayout(visualDelta, scalePercent)
+  expect(layoutDelta).toBeCloseTo(visualDelta / (scalePercent / 100), 6)
+  return startWidth + layoutDelta
+}
+
+describe('pointerDeltaToLayout', () => {
+  it('is the identity at scale 100', () => {
+    expect(pointerDeltaToLayout(123, 100)).toBe(123)
+    expect(pointerDeltaToLayout(-40, 100)).toBe(-40)
+  })
+
+  it('divides visual pixels by the zoom factor at 150% (divider glued to cursor)', () => {
+    // 150 visual px of drag → 100 layout px of panel growth.
+    expect(pointerDeltaToLayout(150, 150)).toBeCloseTo(100, 6)
+    expect(pointerDeltaToLayout(-150, 150)).toBeCloseTo(-100, 6)
+  })
+
+  it('amplifies the delta at 70% (smaller panels need more layout px per visual px)', () => {
+    // 70 visual px of drag → 100 layout px of panel growth.
+    expect(pointerDeltaToLayout(70, 70)).toBeCloseTo(100, 6)
+  })
+
+  it('round-trips with any scale in the supported 50–200 range', () => {
+    for (const scale of [50, 70, 85, 100, 125, 150, 200]) {
+      const layout = pointerDeltaToLayout(300, scale)
+      // The rendered width change (layout × zoom) equals the pointer delta.
+      expect(layout * (scale / 100)).toBeCloseTo(300, 6)
+    }
+  })
+
+  it('falls back to the raw delta for non-finite or non-positive scale', () => {
+    expect(pointerDeltaToLayout(100, Number.NaN)).toBe(100)
+    expect(pointerDeltaToLayout(100, 0)).toBe(100)
+    expect(pointerDeltaToLayout(100, -50)).toBe(100)
+  })
+})
+
+describe('useResize drag compensation', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+  const onChange = vi.fn<(width: number) => void>()
+  // Ref-like stash: the harness writes the live handler here each render so
+  // tests can trigger it without re-implementing React event plumbing.
+  const handleRef: { current: (e: ReactMouseEvent) => void } = { current: () => {} }
+
+  function Harness(): null {
+    const { handleMouseDown } = useResize({
+      initialWidth: 200,
+      min: 50,
+      max: 600,
+      direction: 1,
+      onChange,
+    })
+    handleRef.current = handleMouseDown
+    return null
+  }
+
+  beforeEach(() => {
+    onChange.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root?.render(createElement(Harness))
+    })
+  })
+
+  afterEach(() => {
+    // End any drag left open so document-level listeners are removed.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    act(() => {
+      root?.unmount()
+    })
+    root = null
+    container?.remove()
+    container = null
+    useUiScaleStore.setState({ scale: 100 })
+  })
+
+  function startDrag(clientX: number): void {
+    act(() => {
+      handleRef.current({
+        preventDefault: vi.fn(),
+        clientX,
+        clientY: 0,
+      } as unknown as ReactMouseEvent)
+    })
+  }
+
+  function moveTo(clientX: number): void {
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX, clientY: 0 }))
+    })
+  }
+
+  it('reports raw layout pixels at scale 100', () => {
+    useUiScaleStore.setState({ scale: 100 })
+    startDrag(100)
+    moveTo(250)
+    expect(onChange).toHaveBeenLastCalledWith(350)
+  })
+
+  it('keeps the divider glued to the cursor at scale 150', () => {
+    useUiScaleStore.setState({ scale: 150 })
+    startDrag(100)
+    moveTo(250) // 150 visual px of drag
+    const expected = expectGlued(150, 150, 200)
+    expect(onChange).toHaveBeenLastCalledWith(expected) // 300, not 350
+    expect(onChange).toHaveBeenLastCalledWith(300)
+  })
+
+  it('keeps the divider glued to the cursor at scale 70', () => {
+    useUiScaleStore.setState({ scale: 70 })
+    startDrag(100)
+    moveTo(170) // 70 visual px of drag
+    const expected = expectGlued(70, 70, 200)
+    expect(onChange).toHaveBeenLastCalledWith(expected) // 300
+  })
+
+  it('applies the current scale even when it changes mid-drag', () => {
+    useUiScaleStore.setState({ scale: 100 })
+    startDrag(100)
+    moveTo(150) // +50 visual px at 100% → width 200 + 50 = 250
+    expect(onChange).toHaveBeenLastCalledWith(250)
+    // User changes zoom mid-drag (settings slider). The next move recomputes
+    // from drag start (startWidth + full-drag delta / zoom): the full 200px
+    // visual drag at 150% is ~133.3 layout px → width ~333.3. The divider
+    // still tracks the cursor position, just from the new zoom basis.
+    useUiScaleStore.setState({ scale: 150 })
+    moveTo(300) // 200 visual px since drag start → /1.5 → 200 + 133.33
+    expect(onChange).toHaveBeenLastCalledWith(200 + 200 / 1.5)
+  })
+
+  it('still clamps the compensated delta to max', () => {
+    useUiScaleStore.setState({ scale: 150 })
+    startDrag(0)
+    moveTo(1200) // 1200 visual px → 800 layout px → clamped to 600
+    expect(onChange).toHaveBeenLastCalledWith(600)
+  })
+
+  it('still clamps the compensated delta to min', () => {
+    useUiScaleStore.setState({ scale: 50 })
+    startDrag(100)
+    moveTo(-400) // -500 visual px → -1000 layout px → clamped to 50
+    expect(onChange).toHaveBeenLastCalledWith(50)
+  })
+})

--- a/frontend/src/hooks/useResize.ts
+++ b/frontend/src/hooks/useResize.ts
@@ -1,4 +1,23 @@
 import { useRef, useCallback, useEffect, type MouseEvent as ReactMouseEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useUiScaleStore } from '@/stores/uiScaleStore'
+
+/**
+ * Converts a pointer displacement measured in on-screen (device/visual)
+ * pixels into CSS-layout pixels by dividing out the UI zoom factor.
+ *
+ * The app-wide UI scale is applied via CSS `zoom` on <html>, so mouse event
+ * coordinates arrive zoom-multiplied while the panel widths this hook
+ * reports are layout pixels. Without the division the divider would
+ * overshoot the cursor by exactly the zoom factor: at 150% a 100px visual
+ * drag must grow the panel by 100 visual px = ~66.7 layout px, not 100.
+ *
+ * A non-finite or non-positive scale (defensive: corrupt persisted state)
+ * falls back to the raw delta, i.e. behaves like scale 100%.
+ */
+export function pointerDeltaToLayout(delta: number, uiScalePercent: number): number {
+  if (!Number.isFinite(uiScalePercent) || uiScalePercent <= 0) return delta
+  return (delta * 100) / uiScalePercent
+}
 
 interface UseResizeOptions {
   initialWidth: number
@@ -63,7 +82,12 @@ export function useResize({ initialWidth, min, max, direction = 1, axis = 'x', o
 
     const onMouseMove = (ev: MouseEvent) => {
       if (!dragging.current) return
-      const delta = ((axis === 'y' ? ev.clientY : ev.clientX) - startX.current) * direction
+      // Compensate the visual-pixel pointer delta for the app-wide UI zoom
+      // so the divider stays glued to the cursor at any scale (150% → /1.5).
+      // Read per-move via getState(): keeps the handler free of stale
+      // closures and tracks a scale change even mid-drag.
+      const rawDelta = ((axis === 'y' ? ev.clientY : ev.clientX) - startX.current) * direction
+      const delta = pointerDeltaToLayout(rawDelta, useUiScaleStore.getState().scale)
       onChangeRef.current(clamp(startWidth.current + delta, min, max))
     }
 

--- a/frontend/src/hooks/useVerticalSplit.ts
+++ b/frontend/src/hooks/useVerticalSplit.ts
@@ -68,6 +68,10 @@ export function useVerticalSplit({
       if (!dragging.current) return
       const rect = container.getBoundingClientRect()
       if (rect.height <= 0) return
+      // Zoom-invariant by construction: both clientY and rect.top/bottom come
+      // from the same getBoundingClientRect()/mouse-event visual-pixel space,
+      // so CSS `zoom` on <html> cancels out of the ratio. No scale
+      // compensation is needed here (unlike the pixel-based useResize).
       const next = (ev.clientY - rect.top) / rect.height
       onChangeRef.current(clamp(next, min, max))
     }

--- a/frontend/src/lib/floatingUiZoom.test.ts
+++ b/frontend/src/lib/floatingUiZoom.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Platform, Rect } from '@floating-ui/dom'
+
+// jsdom in this environment does not expose `window.localStorage`, which
+// zustand's `persist` middleware captures at store-creation time. Install an
+// in-memory polyfill before any store module is imported (same pattern as
+// themeStore.test.ts) so uiScaleStore — imported by floatingUiZoom — works.
+vi.hoisted(() => {
+  const g = globalThis as Record<string, unknown>
+  const win = (g.window as Record<string, unknown> | undefined) ?? g
+  const map = new Map<string, string>()
+  win.localStorage = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v) },
+    removeItem: (k: string) => { map.delete(k) },
+    clear: () => { map.clear() },
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    get length() { return map.size },
+  }
+})
+
+import { installFloatingUiZoomCompensation } from './floatingUiZoom'
+import { useUiScaleStore } from '@/stores/uiScaleStore'
+
+/** Visual-px geometry the mock reports at zoom 1 (as a browser would). */
+const REF_RECT: Rect = { x: 300, y: 150, width: 450, height: 60 }
+const FLOATING_DIMENSIONS = { width: 200, height: 100 }
+const CLIPPING_RECT: Rect = { x: 0, y: 0, width: 1400, height: 900 }
+const CONVERT_RECT: Rect = { x: 300, y: 150, width: 200, height: 80 }
+
+/**
+ * Fresh mock platform whose geometry methods mimic the stock signatures and
+ * report visual px (what a zoomed browser serves from
+ * getBoundingClientRect / visualViewport). Each spy records its calls so the
+ * tests can also assert `getDimensions` is never routed through a wrapper.
+ */
+function makeMockPlatform() {
+  const getElementRects = vi.fn(async () => ({
+    reference: { ...REF_RECT },
+    floating: { x: 0, y: 0, ...FLOATING_DIMENSIONS },
+  }))
+  const getClippingRect = vi.fn(async () => ({ ...CLIPPING_RECT }))
+  const convert = vi.fn(async () => ({ ...CONVERT_RECT }))
+  const getDimensions = vi.fn(async () => ({ ...FLOATING_DIMENSIONS }))
+  const platform = {
+    _c: new Map(),
+    getElementRects,
+    getClippingRect,
+    convertOffsetParentRelativeRectToViewportRelativeRect: convert,
+    getDimensions,
+    getOffsetParent: vi.fn(async () => window),
+    isElement: vi.fn(async () => true),
+    getDocumentElement: vi.fn(() => document.documentElement),
+    getClientRects: vi.fn(() => []),
+    isRTL: vi.fn(async () => false),
+    getScale: vi.fn(async () => ({ x: 1, y: 1 })),
+  } as unknown as Platform & Record<string, ReturnType<typeof vi.fn>>
+  return { platform, getElementRects, getClippingRect, convert, getDimensions }
+}
+
+const RECT_ARGS = {
+  reference: document.createElement('div'),
+  floating: document.createElement('div'),
+  strategy: 'fixed' as const,
+}
+
+function setZoom(percent: number) {
+  useUiScaleStore.setState({ scale: percent })
+}
+
+describe('installFloatingUiZoomCompensation', () => {
+  beforeEach(() => {
+    setZoom(100)
+  })
+
+  it('divides reference rect coordinates by 1.5 at 150% zoom', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(150)
+    const rects = await mock.platform.getElementRects(RECT_ARGS)
+    expect(rects.reference.x).toBeCloseTo(200)
+    expect(rects.reference.y).toBeCloseTo(100)
+    expect(rects.reference.width).toBeCloseTo(300)
+    expect(rects.reference.height).toBeCloseTo(40)
+    // Floating rect comes from getDimensions (layout px) — must stay stock.
+    expect(rects.floating.width).toBe(200)
+    expect(rects.floating.height).toBe(100)
+    expect(rects.floating.x).toBe(0)
+    expect(rects.floating.y).toBe(0)
+  })
+
+  it('divides reference rect coordinates by 0.7 at 70% zoom', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(70)
+    const rects = await mock.platform.getElementRects(RECT_ARGS)
+    expect(rects.reference.x).toBeCloseTo(428.571, 2)
+    expect(rects.reference.y).toBeCloseTo(214.285, 2)
+    expect(rects.reference.width).toBeCloseTo(642.857, 2)
+    expect(rects.floating.width).toBe(200)
+    expect(rects.floating.height).toBe(100)
+  })
+
+  it('is identity at 100% zoom — the stock result object passes through', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(100)
+    const rects = await mock.platform.getElementRects(RECT_ARGS)
+    // Same values as the mock produced, and the very same object identity:
+    // at zoom 1 the wrapper short-circuits without touching the result.
+    expect(rects).toBe(await Promise.resolve(
+      await (mock.getElementRects.mock.results[0]?.value as ReturnType<typeof mock.getElementRects>),
+    ))
+    expect(rects.reference.x).toBe(300)
+    expect(rects.reference.width).toBe(450)
+  })
+
+  it('divides getClippingRect output by the zoom factor', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(150)
+    const rect = await mock.platform.getClippingRect({
+      element: document.createElement('div'),
+      boundary: 'clippingAncestors',
+      rootBoundary: 'viewport',
+      strategy: 'fixed',
+    })
+    expect(rect.x).toBeCloseTo(0)
+    expect(rect.y).toBeCloseTo(0)
+    expect(rect.width).toBeCloseTo(933.333, 2)
+    expect(rect.height).toBeCloseTo(600)
+  })
+
+  it('divides convertOffsetParentRelativeRect… by NOTHING — it is left stock', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(150)
+    const rect = await mock.platform.convertOffsetParentRelativeRectToViewportRelativeRect({
+      rect: { ...CONVERT_RECT },
+      offsetParent: document.body,
+      strategy: 'fixed',
+    })
+    // Core feeds this method values that are already in floating-ui's
+    // internal space (candidate position / compensated reference rect);
+    // dividing here double-compensates and breaks shift/flip (empirically
+    // verified at 70% zoom). The method must remain the untouched mock.
+    expect(mock.convert).toHaveBeenCalledTimes(1)
+    expect(rect.x).toBe(CONVERT_RECT.x)
+    expect(rect.y).toBe(CONVERT_RECT.y)
+    expect(rect.width).toBe(CONVERT_RECT.width)
+    expect(rect.height).toBe(CONVERT_RECT.height)
+  })
+
+  it('never wraps getDimensions (already layout px via offsetWidth fallback)', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(150)
+    const dims = await mock.platform.getDimensions(document.createElement('div'))
+    // Untouched mock: the install function never replaces this method.
+    expect(mock.getDimensions).toHaveBeenCalledTimes(1)
+    expect(dims.width).toBe(200)
+    expect(dims.height).toBe(100)
+  })
+
+  it('is idempotent — installing twice never double-divides', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    installFloatingUiZoomCompensation(mock.platform)
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(150)
+    const rects = await mock.platform.getElementRects(RECT_ARGS)
+    // One division only: 300 / 1.5 = 200 (not 300 / 1.5 / 1.5).
+    expect(rects.reference.x).toBeCloseTo(200)
+    const rect = await mock.platform.getClippingRect({
+      element: document.createElement('div'),
+      boundary: 'clippingAncestors',
+      rootBoundary: 'viewport',
+      strategy: 'fixed',
+    })
+    expect(rect.width).toBeCloseTo(933.333, 2)
+  })
+
+  it('keeps the stock method as the inner call (spies still record invocations)', async () => {
+    const mock = makeMockPlatform()
+    installFloatingUiZoomCompensation(mock.platform)
+    setZoom(150)
+    await mock.platform.getElementRects(RECT_ARGS)
+    expect(mock.getElementRects).toHaveBeenCalledTimes(1)
+    await mock.platform.convertOffsetParentRelativeRectToViewportRelativeRect({
+      rect: { ...CONVERT_RECT },
+      offsetParent: document.body,
+      strategy: 'fixed',
+    })
+    expect(mock.convert).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the patched platform object', () => {
+    const mock = makeMockPlatform()
+    const returned = installFloatingUiZoomCompensation(mock.platform)
+    expect(returned).toBe(mock.platform)
+  })
+})

--- a/frontend/src/lib/floatingUiZoom.ts
+++ b/frontend/src/lib/floatingUiZoom.ts
@@ -1,0 +1,184 @@
+import { platform, type Platform } from '@floating-ui/dom'
+import { getUiZoomFactor } from '@/stores/uiScaleStore'
+
+/**
+ * Zoom compensation for @floating-ui/dom.
+ *
+ * Why this exists
+ * ───────────────
+ * The app-wide UI scale is applied as CSS `zoom` on <html>. Under that zoom:
+ *   - `getBoundingClientRect()` and pointer `clientX/Y` report VISUAL px
+ *     (layout px × zoom factor),
+ *   - `style.left/top` on elements inside the zoomed root are written and
+ *     interpreted in LAYOUT px.
+ * floating-ui measures the reference with `getBoundingClientRect()` and
+ * returns those coordinates for the caller to write into `style.left/top` —
+ * a visual→layout unit mismatch that displaces every popover/tooltip/menu
+ * by exactly `position × (zoom − 1)` (at 150% a popover lands 50% further
+ * from its anchor than intended, often outside the viewport).
+ *
+ * The mismatch cannot be fixed by floating-ui's own scale handling
+ * (`getScale`/`includeScale`): for Radix portaled content positioned with
+ * `strategy: 'fixed'`, the floating element's offset parent resolves to the
+ * Window, and floating-ui's `getBoundingClientRect` helper only applies its
+ * scale division when the offset parent is a real element — so the reference
+ * rect is never divided.
+ *
+ * The fix
+ * ───────
+ * Wrap the geometry-producing methods of the shared `platform` object so the
+ * rects they hand to the positioning engine are converted from visual px to
+ * layout px (dividing by the zoom factor, read live at call time — never
+ * cached):
+ *
+ *   - `getElementRects` — divide the REFERENCE rect only. The floating side
+ *     comes from `getDimensions`, whose `offsetWidth` fallback already
+ *     yields layout px.
+ *   - `getClippingRect` — divide the returned rect (built from
+ *     `html.clientWidth`/`visualViewport`/`getBoundingClientRect`, i.e.
+ *     visual px) so overflow/flip/shift math runs in the same layout-px
+ *     space.
+ *   - `convertOffsetParentRelativeRectToViewportRelativeRect` — deliberately
+ *     NOT wrapped: @floating-ui/core only ever feeds it values that are
+ *     already in floating-ui's internal (layout-px after the
+ *     getElementRects compensation) space — the floating candidate position
+ *     or the compensated rects.reference. Dividing its output
+ *     double-compensates and makes detectOverflow report phantom overflow
+ *     (verified empirically at 70%: popovers dragged ~590 visual px left).
+ *   - `getDimensions` — deliberately NOT wrapped: `getCssDimensions` falls
+ *     back to `offsetWidth`/`offsetHeight` (layout px) under zoom already.
+ *
+ * `this` handling matters: `computePosition` builds a per-call copy of the
+ * platform (`{...platform, _c: cache}`) and invokes the methods on it, so
+ * the stock implementations read their clipping-ancestor cache (`this._c`)
+ * and sibling methods (`this.getDimensions`) off that copy. The wrappers
+ * below therefore preserve the caller's receiver instead of rebinding it.
+ *
+ * Mutating the shared `platform` instance is what makes this work for Radix:
+ * `@floating-ui/react-dom` re-exports the very same object and reads the
+ * method values from it, `@floating-ui/core` middleware read geometry
+ * exclusively through the platform, and the package is deduplicated to a
+ * single copy in node_modules.
+ *
+ * At zoom 1.0 every compensation is an identity — the stock result object is
+ * returned untouched, so 100% behaves bit-for-bit like stock floating-ui.
+ * Installation is idempotent and expected to run once at startup
+ * (main.tsx), before any popover opens.
+ */
+
+/** Minimal rect shape shared by the wrapped platform methods. */
+interface RectLike {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** Argument shape of Platform['getElementRects']. */
+type ElementRectsArgs = Parameters<Platform['getElementRects']>[0]
+
+/** Result shape of Platform['getElementRects']. */
+type ElementRectsResult = {
+  reference: RectLike
+  floating: RectLike
+}
+
+/** Marks a platform method as already wrapped (idempotency flag). */
+const COMPENSATED = Symbol('c0wrk-floating-ui-zoom-compensation')
+
+function isCompensated(fn: unknown): boolean {
+  return (
+    typeof fn === 'function' && (fn as { [COMPENSATED]?: boolean })[COMPENSATED] === true
+  )
+}
+
+/** Return a copy of `rect` with every coordinate divided by `k`. */
+function divideRect<T extends RectLike>(rect: T, k: number): T {
+  return {
+    ...rect,
+    x: rect.x / k,
+    y: rect.y / k,
+    width: rect.width / k,
+    height: rect.height / k,
+  }
+}
+
+/** Receiver type the wrappers forward to the stock methods (per-call copy). */
+type PlatformReceiver = { _c?: Map<unknown, unknown[]> } & Record<string, unknown>
+
+/**
+ * Wrap a platform geometry method, preserving the caller's receiver so the
+ * stock implementation keeps seeing its per-call `_c` cache and sibling
+ * methods. Converts the produced value from visual px to layout px with
+ * `compensate(result, zoom)`; at zoom 1 the stock result is returned as-is
+ * (same object identity).
+ */
+function wrapRectMethod<TArgs, TResult extends object>(
+  base: (this: PlatformReceiver, args: TArgs) => TResult | Promise<TResult>,
+  compensate: (result: TResult, zoom: number) => TResult,
+): (this: PlatformReceiver, args: TArgs) => TResult | Promise<TResult> {
+  const wrapped = function (
+    this: PlatformReceiver,
+    args: TArgs,
+  ): TResult | Promise<TResult> {
+    const result = base.call(this, args)
+    const zoom = getUiZoomFactor()
+    if (zoom === 1) return result
+    return Promise.resolve(result).then((r) => compensate(r, zoom))
+  }
+  ;(wrapped as { [COMPENSATED]?: boolean })[COMPENSATED] = true
+  return wrapped
+}
+
+/**
+ * Install the zoom compensation on the shared @floating-ui/dom `platform`
+ * (or an explicit target — used by tests). Wraps `getElementRects` and
+ * `getClippingRect` as described in the module comment; `getDimensions` and
+ * `convertOffsetParentRelativeRectToViewportRelativeRect` are left stock.
+ * Idempotent: already-wrapped methods are never re-wrapped. Returns the
+ * patched platform object.
+ */
+export function installFloatingUiZoomCompensation(target: Platform = platform): Platform {
+  const current = target
+
+  if (!isCompensated(current.getElementRects)) {
+    // The cast drops only the parameter type (the receiver type is added by
+    // wrapRectMethod); no .bind on purpose: floating-ui's computePosition
+    // invokes these methods on a per-call copy ({...platform, _c: cache}),
+    // and the stock implementations read that cache and sibling methods off
+    // the receiver. The wrapper forwards the caller's receiver so they keep
+    // working.
+    const base = current.getElementRects as unknown as (
+      this: PlatformReceiver,
+      args: ElementRectsArgs,
+    ) => ElementRectsResult | Promise<ElementRectsResult>
+    current.getElementRects = wrapRectMethod(
+      base,
+      // Divide only the reference rect; the floating side comes from
+      // getDimensions and is already layout px.
+      (rects, zoom) => ({ ...rects, reference: divideRect(rects.reference, zoom) }),
+    ) as unknown as Platform['getElementRects']
+  }
+
+  if (!isCompensated(current.getClippingRect)) {
+    const base = current.getClippingRect as unknown as (
+      this: PlatformReceiver,
+      args: never,
+    ) => RectLike | Promise<RectLike>
+    current.getClippingRect = wrapRectMethod(
+      base,
+      (rect, zoom) => divideRect(rect, zoom),
+    ) as unknown as Platform['getClippingRect']
+  }
+
+  // NOTE: convertOffsetParentRelativeRectToViewportRelativeRect is
+  // deliberately NOT wrapped. @floating-ui/core feeds it either the floating
+  // element's candidate position ({x, y} in floating-ui's internal — after
+  // the getElementRects compensation, layout — space) or rects.reference
+  // (already compensated layout px). Dividing its output would
+  // double-compensate and make detectOverflow report phantom overflow,
+  // dragging popovers sideways (verified empirically at 70% zoom: content
+  // right edge landed ~590 visual px left of the anchor).
+
+  return current
+}

--- a/frontend/src/lib/usePanZoom.test.ts
+++ b/frontend/src/lib/usePanZoom.test.ts
@@ -14,6 +14,7 @@ import {
   usePanZoom,
   zoomToPoint,
 } from './usePanZoom'
+import { useUiScaleStore } from '@/stores/uiScaleStore'
 
 describe('clampScale', () => {
   it('passes in-range values through', () => {
@@ -256,6 +257,7 @@ function PanProbe() {
     ref: canvasRef,
     'data-testid': 'pan-canvas',
     'data-x': String(view.x),
+    'data-y': String(view.y),
     'data-scale': String(view.scale),
     'data-drag': didDragRef.current ? '1' : '0',
     onPointerDown,
@@ -550,5 +552,119 @@ describe('usePanZoom rAF-coalesced pan commits', () => {
     // waiting for an animation frame.
     expect(canvas.getAttribute('data-x')).toBe('10')
     expect(scheduledFrames()).toBe(0)
+  })
+})
+
+// ── UI-zoom compensation (visual px → layout px) ────────────────────────
+//
+// The app-wide UI scale (CSS `zoom` on <html>) multiplies what
+// getBoundingClientRect and pointer clientX/Y report (visual px) while the
+// view transform stays layout px. The hook must divide every visual input
+// by the zoom factor: wheel anchors, pan deltas and the fit measurement.
+
+describe('usePanZoom UI-zoom compensation', () => {
+  beforeEach(() => {
+    useUiScaleStore.setState({ scale: 100 })
+  })
+
+  it('compensates the wheel anchor: a zoom keeps the content point under the cursor fixed', () => {
+    const { canvas } = renderProbe()
+    // jsdom rects are 0x0, so the raw anchor is the bare clientX/Y.
+    // Simulate a 150% UI zoom: the browser would serve the same 60/40
+    // clientX/Y as visual px; without compensation the hook would feed
+    // zoom × anchor into the layout-px transform.
+    useUiScaleStore.setState({ scale: 150 })
+    // The canvas visual rect left/top are 0 in jsdom regardless of zoom, so
+    // the anchor is clientX/Y as-is; the hook must divide it by 1.5.
+    act(() => {
+      canvas.dispatchEvent(
+        new WheelEvent('wheel', { cancelable: true, deltaX: 0, deltaY: -100, clientX: 60, clientY: 40 }),
+      )
+    })
+    expect(canvas.getAttribute('data-scale')).toBe('1.25')
+    // Anchor (60/1.5, 40/1.5) = (40, 26.67): x = 40 − 1.25·40 = −10;
+    // y = 26.67 − 1.25·26.67 = −6.67.
+    expect(Number(canvas.getAttribute('data-x'))).toBeCloseTo(-10, 5)
+    expect(Number(canvas.getAttribute('data-y'))).toBeCloseTo(-40 / 1.5 * 0.25, 5)
+  })
+
+  it('wheel compensation is identity at 100% zoom', () => {
+    const { canvas } = renderProbe()
+    act(() => {
+      canvas.dispatchEvent(
+        new WheelEvent('wheel', { cancelable: true, deltaX: 0, deltaY: -100, clientX: 60, clientY: 40 }),
+      )
+    })
+    expect(canvas.getAttribute('data-scale')).toBe('1.25')
+    expect(Number(canvas.getAttribute('data-x'))).toBeCloseTo(-15, 5)
+    expect(Number(canvas.getAttribute('data-y'))).toBeCloseTo(-10, 5)
+  })
+
+  it('compensates pan deltas: a visual drag of 150px at 150% pans exactly 100 layout px', () => {
+    const { canvas } = renderProbe()
+    useUiScaleStore.setState({ scale: 150 })
+    act(() => {
+      firePointer(canvas, 'pointerdown', 100, 100)
+      firePointer(canvas, 'pointermove', 250, 100) // 150 visual px
+      firePointer(canvas, 'pointerup', 250, 100)
+    })
+    // 150 visual px / 1.5 = 100 layout px; the content on screen moves
+    // 100 × 1.5 = 150 visual px — glued to the cursor.
+    expect(canvas.getAttribute('data-x')).toBe('100')
+  })
+
+  it('compensates pan deltas at 70% zoom', () => {
+    const { canvas } = renderProbe()
+    useUiScaleStore.setState({ scale: 70 })
+    act(() => {
+      firePointer(canvas, 'pointerdown', 100, 100)
+      firePointer(canvas, 'pointermove', 170, 100) // 70 visual px
+      firePointer(canvas, 'pointerup', 170, 100)
+    })
+    // 70 visual px / 0.7 = 100 layout px.
+    expect(canvas.getAttribute('data-x')).toBe('100')
+  })
+
+  it('pan-delta compensation is identity at 100% zoom', () => {
+    const { canvas } = renderProbe()
+    act(() => {
+      firePointer(canvas, 'pointerdown', 100, 100)
+      firePointer(canvas, 'pointermove', 200, 100)
+      firePointer(canvas, 'pointerup', 200, 100)
+    })
+    expect(canvas.getAttribute('data-x')).toBe('100')
+  })
+
+  it('reads the zoom factor live, so a mid-gesture scale change applies from that point', () => {
+    const { canvas } = renderProbe()
+    act(() => {
+      firePointer(canvas, 'pointerdown', 100, 100)
+      firePointer(canvas, 'pointermove', 150, 100) // 50 px @100% → 50 layout px
+    })
+    act(() => flushRaf())
+    expect(canvas.getAttribute('data-x')).toBe('50')
+    useUiScaleStore.setState({ scale: 150 })
+    act(() => {
+      firePointer(canvas, 'pointermove', 225, 100) // pointer now 125 visual px from origin
+      firePointer(canvas, 'pointerup', 225, 100)
+    })
+    // dx is recomputed from the drag origin with the LIVE zoom: the whole
+    // displacement (125 visual px) is compensated at 150% → 83.33 layout px,
+    // which renders as 125 visual px — the content stays glued to the cursor.
+    expect(Number(canvas.getAttribute('data-x'))).toBeCloseTo(125 / 1.5, 5)
+  })
+
+  it('keeps DRAG_CLICK_THRESHOLD_PX in visual px (threshold semantics unaffected by zoom)', () => {
+    const { canvas, captureSpy } = renderProbe()
+    useUiScaleStore.setState({ scale: 150 })
+    act(() => {
+      firePointer(canvas, 'pointerdown', 100, 100)
+      // 5 visual px > 4px threshold → pan engages even at 150% (3.33 layout
+      // px would fail a layout-px threshold read).
+      firePointer(canvas, 'pointermove', 105, 100)
+    })
+    expect(captureSpy).toHaveBeenCalledTimes(1)
+    act(() => flushRaf())
+    expect(canvas.getAttribute('data-drag')).toBe('1')
   })
 })

--- a/frontend/src/lib/usePanZoom.ts
+++ b/frontend/src/lib/usePanZoom.ts
@@ -9,6 +9,7 @@ import {
   type SetStateAction,
   type PointerEvent as ReactPointerEvent,
 } from 'react'
+import { getUiZoomFactor } from '@/stores/uiScaleStore'
 
 /** Default lower zoom limit (inclusive). */
 export const DEFAULT_MIN_SCALE = 0.2
@@ -101,10 +102,13 @@ export function isHorizontalWheelGesture(deltaX: number, deltaY: number): boolea
 function measureSvgNaturalSize(container: HTMLElement | null, activeScale: number): Size | null {
   const svgEl = container?.querySelector('svg')
   if (!svgEl) return null
+  // getBoundingClientRect() reports visual px (layout × UI zoom); the view
+  // transform we recover from it is layout px — divide the zoom out first.
+  const zoom = getUiZoomFactor()
   const rect = svgEl.getBoundingClientRect()
   const prevScale = activeScale || 1
-  let width = rect.width / prevScale
-  let height = rect.height / prevScale
+  let width = rect.width / zoom / prevScale
+  let height = rect.height / zoom / prevScale
   if (!width || !height) {
     const attrW = parseFloat(svgEl.getAttribute('width') ?? '')
     const attrH = parseFloat(svgEl.getAttribute('height') ?? '')
@@ -280,7 +284,9 @@ export function usePanZoom(options: UsePanZoomOptions = {}): UsePanZoomResult {
     (factor: number) => {
       const rect = canvasRef.current?.getBoundingClientRect()
       if (!rect) return
-      zoomAt(factor, rect.width / 2, rect.height / 2)
+      // rect is visual px; the view transform is layout px.
+      const zoom = getUiZoomFactor()
+      zoomAt(factor, rect.width / zoom / 2, rect.height / zoom / 2)
     },
     [zoomAt],
   )
@@ -302,10 +308,13 @@ export function usePanZoom(options: UsePanZoomOptions = {}): UsePanZoomResult {
       if (e.deltaX === 0 && e.deltaY === 0) return
       e.preventDefault()
       const rect = canvas.getBoundingClientRect()
+      // Pointer coords and the rect are both visual px, so their difference
+      // is visual too; the view transform is layout px — divide the zoom out.
+      const zoom = getUiZoomFactor()
       zoomAt(
         e.deltaY < 0 ? zoomStep : 1 / zoomStep,
-        e.clientX - rect.left,
-        e.clientY - rect.top,
+        (e.clientX - rect.left) / zoom,
+        (e.clientY - rect.top) / zoom,
       )
     }
     canvas.addEventListener('wheel', onWheel, { passive: false })
@@ -447,12 +456,18 @@ export function usePanZoom(options: UsePanZoomOptions = {}): UsePanZoomResult {
         finishDrag(e.pointerId)
         return
       }
-      const dx = e.clientX - drag.startX
-      const dy = e.clientY - drag.startY
+      // clientX/Y are visual px (layout × UI zoom) while view.x/y are layout
+      // px: divide the displacement by the zoom factor or the content would
+      // track the cursor at ×zoom speed (1.5× too fast at 150%).
+      const zoom = getUiZoomFactor()
+      const dx = (e.clientX - drag.startX) / zoom
+      const dy = (e.clientY - drag.startY) / zoom
       // Drag-distance counter: once the pointer has travelled further than the
       // click threshold, the gesture is a pan — consumers checking didDragRef
-      // in onClick suppress the trailing click.
-      if (!didDragRef.current && Math.hypot(dx, dy) > DRAG_CLICK_THRESHOLD_PX) {
+      // in onClick suppress the trailing click. The threshold stays in visual
+      // px on purpose: it expresses pointer intent (a real hand movement),
+      // which zoom does not change.
+      if (!didDragRef.current && Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) > DRAG_CLICK_THRESHOLD_PX) {
         didDragRef.current = true
         // The gesture is now definitively a pan (not a click), so it is safe —
         // and necessary — to capture the pointer: tracking continues even when

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,12 +6,26 @@ import { registerLanguages } from './lib/hljsLanguages'
 import '@xterm/xterm/css/xterm.css'
 import './index.css'
 import { useThemeStore, applyThemeToDocument } from './stores/themeStore'
+import { useUiScaleStore, applyScaleToDocument } from './stores/uiScaleStore'
+import { installFloatingUiZoomCompensation } from './lib/floatingUiZoom'
 
 // Apply the persisted theme before first paint to avoid a flash of the
 // default (dark) theme. Accessing getState() rehydrates from localStorage
 // synchronously; applyThemeToDocument writes <html data-theme> so the CSS
 // token override is in place before React renders anything.
 applyThemeToDocument(useThemeStore.getState().theme)
+
+// Same first-paint contract as the theme above: apply the persisted UI scale
+// (<html style="zoom">) before React renders, so the layout never flashes at
+// 100% for users who changed the zoom level.
+applyScaleToDocument(useUiScaleStore.getState().scale)
+
+// Patch @floating-ui/dom's shared platform so popovers/tooltips/menus
+// position correctly under the zoom: floating-ui measures references in
+// visual px (getBoundingClientRect) but the caller writes its result into
+// style.left/top in layout px. Must run before any popover opens; the
+// wrappers read the live zoom factor on every call.
+installFloatingUiZoomCompensation()
 
 registerLanguages()
 

--- a/frontend/src/stores/uiScaleStore.test.ts
+++ b/frontend/src/stores/uiScaleStore.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// jsdom in this environment does not expose `window.localStorage`, which
+// zustand's `persist` middleware captures at store-creation time (via
+// createJSONStorage(() => window.localStorage)). Install an in-memory
+// polyfill before any store module is imported so uiScaleStore works.
+vi.hoisted(() => {
+  const g = globalThis as Record<string, unknown>
+  const win = (g.window as Record<string, unknown> | undefined) ?? g
+  const map = new Map<string, string>()
+  win.localStorage = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v) },
+    removeItem: (k: string) => { map.delete(k) },
+    clear: () => map.clear(),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    get length() { return map.size },
+  }
+})
+
+import {
+  useUiScaleStore,
+  applyScaleToDocument,
+  dispatchUiResizeNotification,
+  getUiZoomFactor,
+  UI_SCALE_MIN,
+  UI_SCALE_MAX,
+} from '@/stores/uiScaleStore'
+
+describe('uiScaleStore', () => {
+  beforeEach(() => {
+    // Reset to default and clear any persisted state between tests.
+    useUiScaleStore.setState({ scale: 100 })
+    localStorage.clear()
+    document.documentElement.style.zoom = ''
+  })
+
+  it('defaults to 100', () => {
+    expect(useUiScaleStore.getState().scale).toBe(100)
+  })
+
+  it('exposes the documented scale bounds', () => {
+    expect(UI_SCALE_MIN).toBe(50)
+    expect(UI_SCALE_MAX).toBe(200)
+  })
+
+  it('setScale clamps below the minimum', () => {
+    const { setScale } = useUiScaleStore.getState()
+    setScale(49)
+    expect(useUiScaleStore.getState().scale).toBe(50)
+  })
+
+  it('setScale clamps above the maximum', () => {
+    const { setScale } = useUiScaleStore.getState()
+    setScale(300)
+    expect(useUiScaleStore.getState().scale).toBe(200)
+  })
+
+  it('setScale rounds to a whole percent', () => {
+    const { setScale } = useUiScaleStore.getState()
+    setScale(112.6)
+    expect(useUiScaleStore.getState().scale).toBe(113)
+  })
+
+  it('setScale applies the zoom factor to <html>', () => {
+    const { setScale } = useUiScaleStore.getState()
+    setScale(150)
+    expect(document.documentElement.style.zoom).toBe('1.5')
+  })
+
+  it('applyScaleToDocument writes the zoom style directly', () => {
+    applyScaleToDocument(125)
+    expect(document.documentElement.style.zoom).toBe('1.25')
+    applyScaleToDocument(100)
+    expect(document.documentElement.style.zoom).toBe('1')
+  })
+
+  it('getUiZoomFactor reads scale/100 straight from the store state', () => {
+    useUiScaleStore.setState({ scale: 100 })
+    expect(getUiZoomFactor()).toBe(1)
+    useUiScaleStore.setState({ scale: 150 })
+    expect(getUiZoomFactor()).toBe(1.5)
+    useUiScaleStore.setState({ scale: 70 })
+    expect(getUiZoomFactor()).toBe(0.7)
+  })
+
+  it('getUiZoomFactor falls back to 1 on corrupted (non-finite/non-positive) scale', () => {
+    useUiScaleStore.setState({ scale: Number.NaN })
+    expect(getUiZoomFactor()).toBe(1)
+    useUiScaleStore.setState({ scale: 0 })
+    expect(getUiZoomFactor()).toBe(1)
+    useUiScaleStore.setState({ scale: -25 })
+    expect(getUiZoomFactor()).toBe(1)
+  })
+
+  it('setScale dispatches a window resize so open popovers recompute', () => {
+    const onResize = vi.fn()
+    window.addEventListener('resize', onResize)
+    try {
+      useUiScaleStore.getState().setScale(150)
+      expect(onResize).toHaveBeenCalledTimes(1)
+      useUiScaleStore.getState().setScale(170)
+      expect(onResize).toHaveBeenCalledTimes(2)
+    } finally {
+      window.removeEventListener('resize', onResize)
+    }
+  })
+
+  it('dispatchUiResizeNotification is a no-op without window access', () => {
+    // Guarded by `typeof window === 'undefined'`; in jsdom the window exists,
+    // so the no-op branch is covered by construction (the export runs
+    // without throwing on repeated calls).
+    expect(() => dispatchUiResizeNotification()).not.toThrow()
+  })
+
+  it('applyScaleToDocument is a no-op without document', () => {
+    const g = globalThis as Record<string, unknown>
+    const originalDocument = g.document
+    try {
+      delete g.document
+      expect(() => applyScaleToDocument(150)).not.toThrow()
+    } finally {
+      g.document = originalDocument
+    }
+  })
+
+  it('persists only {scale} under the c0wrk-ui-scale key', () => {
+    const { setScale } = useUiScaleStore.getState()
+    setScale(133)
+    const raw = localStorage.getItem('c0wrk-ui-scale')
+    expect(raw).not.toBeNull()
+    // zustand's persist middleware wraps the payload as {state, version};
+    // partialize must keep `state` limited to the scale field (no actions).
+    const parsed = JSON.parse(raw as string) as {
+      state: Record<string, unknown>
+      version: number
+    }
+    expect(parsed.state).toEqual({ scale: 133 })
+    expect(parsed.version).toBe(1)
+  })
+})

--- a/frontend/src/stores/uiScaleStore.ts
+++ b/frontend/src/stores/uiScaleStore.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+/** Lowest supported UI scale, in percent. */
+export const UI_SCALE_MIN = 50
+/** Highest supported UI scale, in percent. */
+export const UI_SCALE_MAX = 200
+
+interface UiScaleState {
+  scale: number
+}
+
+interface UiScaleActions {
+  setScale: (scale: number) => void
+}
+
+/** Storage key mirrors the persisted-store convention (c0wrk-*). */
+const STORAGE_KEY = 'c0wrk-ui-scale'
+
+/**
+ * Clamps the scale to [UI_SCALE_MIN, UI_SCALE_MAX] and rounds it to a whole
+ * percent, so fractional or out-of-range input (drags, keyboard steps,
+ * third-party callers) collapses to a canonical value before persistence.
+ */
+function normalizeScale(scale: number): number {
+  const clamped = Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, scale))
+  return Math.round(clamped)
+}
+
+/**
+ * Writes the zoom factor onto <html> and is a no-op when the document is
+ * unavailable (e.g. during tests). Safe to call repeatedly.
+ */
+export function applyScaleToDocument(scale: number): void {
+  if (typeof document === 'undefined') return
+  document.documentElement.style.zoom = String(scale / 100)
+}
+
+/**
+ * Current UI zoom factor (scale / 100), read straight from the store state —
+ * usable outside React (event handlers, plain modules like the floating-ui
+ * compensation and the pan/zoom hook) without a subscription. Falls back to
+ * 1 when the store reports a non-finite/non-positive scale (corrupted
+ * persisted state must never divide geometry by garbage).
+ */
+export function getUiZoomFactor(): number {
+  const scale = useUiScaleStore.getState().scale
+  if (!Number.isFinite(scale) || scale <= 0) return 1
+  return scale / 100
+}
+
+/**
+ * Notify layout-observing code that the coordinate system changed. A zoom
+ * change re-lays-out every element, but no `resize` event fires (the window
+ * itself did not change size), so open floating-ui popovers would keep their
+ * now-stale positions until the next open. Dispatching a window `resize`
+ * triggers floating-ui's `autoUpdate` (which listens on `resize` for open
+ * popovers) to recompute with the new geometry. No-op without a window
+ * (tests); safe to call repeatedly.
+ */
+export function dispatchUiResizeNotification(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event('resize'))
+}
+
+export const useUiScaleStore = create<UiScaleState & UiScaleActions>()(
+  persist(
+    (set) => ({
+      scale: 100,
+
+      setScale: (scale) => {
+        const normalized = normalizeScale(scale)
+        applyScaleToDocument(normalized)
+        set({ scale: normalized })
+        // The zoom just re-laid-out every element without any `resize` event
+        // firing; open popovers must recompute against the new geometry.
+        dispatchUiResizeNotification()
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      version: 1,
+      // Bump version and implement migration when adding/removing/renaming persisted fields.
+      migrate: (persistedState, _version) => persistedState,
+      partialize: (state) => ({ scale: state.scale }),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary

Adds a persisted UI Scale setting that scales the entire interface by a percentage factor. Managed in Settings → General → **UI Scale**: a combobox with presets 70 / 80 / 90 / 100 / 110 / 125 / 150 / 175 / 200% and free-form entry of any integer percent (clamped to 50–200).

The scale is applied as CSS `zoom` on `<html>` — the only mechanism that scales the *whole* UI uniformly: rem-based typography, the ~126 px-hardcoded spots (badges, fixed panel widths), the xterm terminal, and Radix portals alike. It is applied synchronously in `main.tsx` before the first React render (same pattern as the theme), so there is no 100%→N% flash at startup, and changes take effect instantly while the settings modal is open.

Storage follows the theme precedent: zustand + persist in `localStorage` (`c0wrk-ui-scale`) — a per-device UI preference; no backend, config.yaml, or Go changes.

## How it works

- **`uiScaleStore`** — `scale` (default 100), `setScale()` with normalization (round to integer, clamp 50–200), `applyScaleToDocument()` writing `documentElement.style.zoom`, and a dispatched `window` resize so open popovers recompute positions.
- **`EditableCombobox`** — new reusable input-with-presets primitive: Enter/blur commits, out-of-range values clamp, invalid/empty input reverts, Escape discards, dropdown marks the active preset. Built to work inside Radix dialogs.
- **`UIScaleSelector`** — the settings block wiring the store to the combobox.

### Zoom compensation (the important part)

CSS zoom changes the coordinate space: `getBoundingClientRect()` and pointer events report **visual** pixels while element styles use **layout** pixels. Uncompensated, this breaks popover anchoring, drag interactions, and pan/zoom gestures at any scale ≠ 100%. This PR compensates:

- **`floatingUiZoom`** — patches the shared `@floating-ui/dom` platform (dimensions/offsets) so all Radix popovers, tooltips, and menus anchor correctly under zoom.
- **`useResize`** — divides pointer deltas by the zoom factor so panel dividers stay glued to the cursor.
- **`usePanZoom`** — compensates wheel anchors, pan deltas, and fit measurements (Mermaid diagrams, Research DAG).
- **`Terminal`** — refits xterm on scale change so rows/cols always fill the container.
- **`useVerticalSplit`** — no compensation needed (documented why).

## Testing

- New unit tests for every piece: `uiScaleStore`, `EditableCombobox`, `UIScaleSelector`, `floatingUiZoom`, `useResize`, `usePanZoom`.
- Empirical verification in headless Chromium with real components: dropdown popover anchoring at 100/150/70% (sideOffset × zoom, error ≤ 0.01px), Mermaid wheel-drift < 0.1%, pan ratio 1.0, virtualized list OK.
- `npm run lint` clean; `npm test` — 181 files / 2413 tests PASS; `tsc -b` clean.

## Notes for reviewers

- Native chrome (titlebar, system dialogs) is not scaled — expected desktop-app behavior.
- Considered and rejected: Wails native `ZoomFactor` (Windows-only), `html { font-size }` scaling (misses px-hardcode and the terminal).
- Zero Go changes — `make vulncheck`/`fmt-check` unaffected; frontend lint+test gates cover this diff.