### PR TITLE
feat(ui): show the active project and session in the window title

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { useProjectLoader } from '@/hooks/useProjectLoader'
 import { useSessionLoader } from '@/hooks/useSessionLoader'
 import { useSessionEvents } from '@/hooks/useSessionEvents'
 import { useBackgroundSessionWatcher } from '@/hooks/useBackgroundSessionWatcher'
+import { useWindowTitle } from '@/hooks/useWindowTitle'
 import { useSessionStore } from '@/stores/sessionStore'
 import { useProjectStore } from '@/stores/projectStore'
 import { useSettingsStore } from '@/stores/settingsStore'
@@ -64,6 +65,9 @@ function App() {
   useSessionEvents(activeSessionId)
   useBackgroundSessionWatcher()
   useUpdateChecker()
+  // Native window title (c0wrk - Project - Session) — mounted at the root so
+  // the title tracks the active context in every app phase.
+  useWindowTitle()
   // Close-guard subscription — mounted once at the root so app-phase
   // transitions never create an event gap; ExitConfirmDialog (rendered in
   // every phase branch) is a pure view over the store this hook writes.

--- a/frontend/src/api/runtime.ts
+++ b/frontend/src/api/runtime.ts
@@ -26,6 +26,7 @@ declare global {
       EventsEmit(eventName: string, ...data: unknown[]): void
       ClipboardSetText(text: string): Promise<boolean>
       BrowserOpenURL(url: string): void
+      WindowSetTitle(title: string): void
     }
   }
 }
@@ -41,6 +42,7 @@ export function getRuntime(): {
   EventsEmit(eventName: string, ...data: unknown[]): void
   ClipboardSetText(text: string): Promise<boolean>
   BrowserOpenURL(url: string): void
+  WindowSetTitle(title: string): void
 } {
   if (typeof window === 'undefined' || !window.runtime) {
     throw new Error('Wails runtime is not available')
@@ -96,6 +98,18 @@ export function emit(eventName: string, data?: unknown): void {
 export function clipboardSetText(text: string): Promise<boolean> {
   const rt = getRuntime()
   return rt.ClipboardSetText(text)
+}
+
+/** Set the native window title.
+ *
+ *  Unlike the other wrappers here this one NO-OPS when the runtime is absent
+ *  instead of throwing, mirroring `subscribe`: the title is a purely cosmetic
+ *  side effect driven from a `useEffect`, and every hook test runs under
+ *  jsdom without `window.runtime`. A throw would turn a decorative update
+ *  into a render-time failure. */
+export function setWindowTitle(title: string): void {
+  if (typeof window === 'undefined' || !window.runtime) return
+  getRuntime().WindowSetTitle(title)
 }
 
 /** Open a URL in the user's default system browser.

--- a/frontend/src/hooks/useWindowTitle.test.ts
+++ b/frontend/src/hooks/useWindowTitle.test.ts
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+// --- Mock the Wails boundary so tests never touch the native runtime ---
+const { runtimeMocks } = vi.hoisted(() => ({
+  runtimeMocks: { setWindowTitle: vi.fn() },
+}))
+
+vi.mock('@/api/runtime', () => runtimeMocks)
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+import { APP_NAME, CHAT_LABEL, buildWindowTitle, useWindowTitle } from './useWindowTitle'
+import { useProjectStore } from '@/stores/projectStore'
+import { useSessionStore } from '@/stores/sessionStore'
+import type { ProjectInfo, SessionInfo } from '@/types/models'
+
+const NO_PROJECT_ID = '__no_project__'
+
+function makeProject(overrides: Partial<ProjectInfo> & { id: string }): ProjectInfo {
+  return {
+    name: overrides.name ?? `Project ${overrides.id}`,
+    workspace_path: overrides.workspace_path ?? '/tmp',
+    is_external: overrides.is_external ?? false,
+    is_no_project: overrides.is_no_project ?? false,
+    research_root: overrides.research_root ?? '',
+    is_research: overrides.is_research ?? false,
+    created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
+    last_active_at: overrides.last_active_at ?? '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeSession(overrides: Partial<SessionInfo> & { id: string }): SessionInfo {
+  return {
+    project_id: overrides.project_id ?? 'proj-a',
+    name: overrides.name ?? `Session ${overrides.id}`,
+    created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
+    last_active_at: overrides.last_active_at ?? '2026-01-01T00:00:00Z',
+    archived: overrides.archived ?? false,
+    pinned: overrides.pinned ?? false,
+    active: overrides.active ?? false,
+    total_input_tokens: overrides.total_input_tokens ?? 0,
+    total_output_tokens: overrides.total_output_tokens ?? 0,
+    model: overrides.model ?? 'test-model',
+    family: overrides.family ?? 'test',
+    has_unfinished_task: overrides.has_unfinished_task ?? false,
+    ...overrides,
+  }
+}
+
+// --- Pure title assembly -----------------------------------------------------
+
+describe('buildWindowTitle', () => {
+  it('returns the bare app name when no scope is active', () => {
+    expect(buildWindowTitle(null, null)).toBe('c0wrk')
+  })
+
+  it('drops a session that has no project scope (no dangling separator)', () => {
+    expect(buildWindowTitle(null, 'Refactor auth')).toBe('c0wrk')
+  })
+
+  it('renders two segments when a project is active without a session', () => {
+    expect(buildWindowTitle('MyProject', null)).toBe('c0wrk - MyProject')
+  })
+
+  it('renders three segments for a project with an active session', () => {
+    expect(buildWindowTitle('MyProject', 'Refactor auth')).toBe('c0wrk - MyProject - Refactor auth')
+  })
+
+  it('renders the CHAT scope the same way', () => {
+    expect(buildWindowTitle(CHAT_LABEL, 'Quick question')).toBe('c0wrk - CHAT - Quick question')
+  })
+
+  it('treats a blank scope as absent', () => {
+    expect(buildWindowTitle('   ', 'Refactor auth')).toBe('c0wrk')
+  })
+
+  it('treats a blank session name as absent', () => {
+    expect(buildWindowTitle('MyProject', '   ')).toBe('c0wrk - MyProject')
+  })
+
+  it('trims surrounding whitespace from both segments', () => {
+    expect(buildWindowTitle('  MyProject  ', '  Refactor auth  ')).toBe('c0wrk - MyProject - Refactor auth')
+  })
+
+  it('exports the app name used as the first segment', () => {
+    expect(APP_NAME).toBe('c0wrk')
+  })
+})
+
+// --- Hook wiring -------------------------------------------------------------
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function Harness() {
+  useWindowTitle()
+  return null
+}
+
+function renderHook(): void {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const r = createRoot(container)
+  root = r
+  act(() => {
+    r.render(createElement(Harness))
+  })
+}
+
+/** Title most recently pushed to the native runtime. */
+function lastTitle(): string | undefined {
+  const calls = runtimeMocks.setWindowTitle.mock.calls
+  return calls[calls.length - 1]?.[0] as string | undefined
+}
+
+function resetStores() {
+  useProjectStore.setState({
+    projects: null,
+    activeProjectId: null,
+    lastRealProjectId: null,
+    createDialogOpen: false,
+  })
+  useSessionStore.setState({ sessions: null, activeSessionId: null })
+}
+
+beforeEach(() => {
+  runtimeMocks.setWindowTitle.mockReset()
+  resetStores()
+})
+
+afterEach(() => {
+  if (root) {
+    const r = root
+    root = null
+    act(() => {
+      r.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+})
+
+describe('useWindowTitle', () => {
+  it('sets the bare app name on mount with nothing active', () => {
+    renderHook()
+    expect(lastTitle()).toBe('c0wrk')
+  })
+
+  it('adds the project segment once a project becomes active', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+    })
+
+    expect(lastTitle()).toBe('c0wrk - MyProject')
+  })
+
+  it('adds the session segment once a session is selected', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    const session = makeSession({ id: 'sess-1', name: 'Refactor auth' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+      useSessionStore.getState().setSessions([session])
+      useSessionStore.getState().setActiveSessionId('sess-1')
+    })
+
+    expect(lastTitle()).toBe('c0wrk - MyProject - Refactor auth')
+  })
+
+  it('shows CHAT instead of the No Project name', () => {
+    const noProject = makeProject({ id: NO_PROJECT_ID, name: 'No Project', is_no_project: true })
+    const session = makeSession({ id: 'sess-1', project_id: NO_PROJECT_ID, name: 'Quick question' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([noProject])
+      useProjectStore.getState().setActiveProjectId(NO_PROJECT_ID)
+      useSessionStore.getState().setSessions([session])
+      useSessionStore.getState().setActiveSessionId('sess-1')
+    })
+
+    expect(lastTitle()).toBe('c0wrk - CHAT - Quick question')
+  })
+
+  it('follows a project rename without a project switch', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+    })
+
+    act(() => {
+      useProjectStore.getState().updateProject('proj-a', { name: 'Renamed' })
+    })
+
+    expect(lastTitle()).toBe('c0wrk - Renamed')
+  })
+
+  it('follows a session rename (background auto-titling)', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    const session = makeSession({ id: 'sess-1', name: 'Session sess-1' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+      useSessionStore.getState().setSessions([session])
+      useSessionStore.getState().setActiveSessionId('sess-1')
+    })
+    expect(lastTitle()).toBe('c0wrk - MyProject - Session sess-1')
+
+    act(() => {
+      useSessionStore.getState().updateSession('sess-1', { name: 'Refactor auth' })
+    })
+
+    expect(lastTitle()).toBe('c0wrk - MyProject - Refactor auth')
+  })
+
+  it('drops the session segment while a project switch clears session state', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    const next = makeProject({ id: 'proj-b', name: 'OtherProject' })
+    const session = makeSession({ id: 'sess-1', name: 'Refactor auth' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project, next])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+      useSessionStore.getState().setSessions([session])
+      useSessionStore.getState().setActiveSessionId('sess-1')
+    })
+    expect(lastTitle()).toBe('c0wrk - MyProject - Refactor auth')
+
+    // Mirrors useProjectSwitchState: sessions are cleared before the
+    // destination list arrives, so the title honestly drops to two segments.
+    act(() => {
+      useSessionStore.getState().resetForProjectSwitch()
+      useProjectStore.getState().setActiveProjectId('proj-b')
+    })
+
+    expect(lastTitle()).toBe('c0wrk - OtherProject')
+  })
+
+  it('drops the project segment when the active project is deleted', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+    })
+
+    act(() => {
+      useProjectStore.getState().removeProject('proj-a')
+    })
+
+    expect(lastTitle()).toBe('c0wrk')
+  })
+
+  it('does not touch the runtime when an activity bump leaves the text unchanged', () => {
+    const project = makeProject({ id: 'proj-a', name: 'MyProject' })
+    const session = makeSession({ id: 'sess-1', name: 'Refactor auth' })
+    renderHook()
+
+    act(() => {
+      useProjectStore.getState().setProjects([project])
+      useProjectStore.getState().setActiveProjectId('proj-a')
+      useSessionStore.getState().setSessions([session])
+      useSessionStore.getState().setActiveSessionId('sess-1')
+    })
+    const callsBefore = runtimeMocks.setWindowTitle.mock.calls.length
+
+    act(() => {
+      useSessionStore.getState().touchSession('sess-1')
+    })
+
+    expect(runtimeMocks.setWindowTitle.mock.calls.length).toBe(callsBefore)
+    expect(lastTitle()).toBe('c0wrk - MyProject - Refactor auth')
+  })
+})

--- a/frontend/src/hooks/useWindowTitle.ts
+++ b/frontend/src/hooks/useWindowTitle.ts
@@ -1,0 +1,60 @@
+// Native window title — keeps the OS title bar in sync with the active
+// project and session, the way an IDE does:
+//
+//   c0wrk                              no project active (startup)
+//   c0wrk - MyProject                  project active, no session selected
+//   c0wrk - MyProject - Refactor auth  full context
+//   c0wrk - CHAT - Quick question      No Project pseudo-project (CHAT mode)
+//
+// Driven entirely from the two stores rather than from backend events: the
+// project/session lifecycle events already land there (project:switched,
+// project:renamed, session:renamed and the optimistic local rename in
+// ProjectSelector), so a single derived effect covers startup, switching,
+// renaming and deletion without any state of its own.
+
+import { useEffect } from 'react'
+import { setWindowTitle } from '@/api/runtime'
+import { CHAT_LABEL, selectTitleScope, useProjectStore } from '@/stores/projectStore'
+import { selectActiveSessionName, useSessionStore } from '@/stores/sessionStore'
+
+/** Product name — always the first segment. */
+export const APP_NAME = 'c0wrk'
+
+/** Re-exported so callers (and tests) can reason about the CHAT segment
+ *  without reaching into the project store. */
+export { CHAT_LABEL }
+
+/** Separator between title segments, matching common IDE conventions. */
+const SEPARATOR = ' - '
+
+/**
+ * Build the window title from the scope segment (project name, or CHAT) and
+ * the active session name. Segments that are absent — or blank after
+ * trimming — are dropped rather than rendered as empty text, so a session
+ * without a project can never produce a dangling separator.
+ */
+export function buildWindowTitle(scope: string | null, sessionName: string | null): string {
+  const trimmedScope = scope?.trim()
+  if (!trimmedScope) return APP_NAME
+
+  const segments = [APP_NAME, trimmedScope]
+  const trimmedSession = sessionName?.trim()
+  if (trimmedSession) segments.push(trimmedSession)
+  return segments.join(SEPARATOR)
+}
+
+/**
+ * Push the current project/session context into the native window title.
+ *
+ * Both selectors return primitives, so the effect re-runs only when the
+ * visible text actually changes — activity bumps that rebuild store entries
+ * without touching a name do not reach the runtime.
+ */
+export function useWindowTitle(): void {
+  const scope = useProjectStore(selectTitleScope)
+  const sessionName = useSessionStore(selectActiveSessionName)
+
+  useEffect(() => {
+    setWindowTitle(buildWindowTitle(scope, sessionName))
+  }, [scope, sessionName])
+}

--- a/frontend/src/stores/projectStore.ts
+++ b/frontend/src/stores/projectStore.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand'
 import type { ProjectInfo } from '@/types/models'
 
+// --- Constants ---
+
+/** Window-title label for the No Project pseudo-project (CHAT mode). */
+export const CHAT_LABEL = 'CHAT'
+
 // --- Helpers ---
 
 function sortByActivity(projects: ProjectInfo[]): ProjectInfo[] {
@@ -80,6 +85,33 @@ export const useProjectStore = create<ProjectState & ProjectActions>((set) => ({
 
 // --- Selectors (pure functions; usable both in render via
 // useProjectStore(selector) and in event handlers via selector(getState())) ---
+
+/**
+ * Scope segment for the native window title: the label that identifies which
+ * project the window is currently looking at.
+ *
+ * Returns the literal {@link CHAT_LABEL} for the No Project pseudo-project
+ * rather than its stored name ("No Project") — the UI calls that mode CHAT,
+ * and the title bar should match what the user sees in the sidebar toggle.
+ *
+ * Returns null while projects are still loading (`projects === null`) or when
+ * nothing is active, so the caller can fall back to the bare app name instead
+ * of rendering an empty segment.
+ *
+ * Deliberately returns a PRIMITIVE, not the ProjectInfo object: the title
+ * effect must re-run only when the visible text changes. `updateProject` and
+ * `setProjects` rebuild the array (and the touched entry) on every activity
+ * bump, so an object-returning selector would fire the effect for changes the
+ * title cannot show.
+ */
+export function selectTitleScope(state: ProjectState): string | null {
+  if (state.projects === null || state.activeProjectId === null) return null
+  const active = state.projects.find((p) => p.id === state.activeProjectId)
+  if (!active) return null
+  if (active.is_no_project) return CHAT_LABEL
+  const name = active.name.trim()
+  return name === '' ? null : name
+}
 
 /**
  * Returns true when the active project is the No Project (CHAT mode) entry.

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -18,7 +18,7 @@ function sortByActivity(sessions: SessionInfo[]): SessionInfo[] {
 
 // --- State types ---
 
-interface SessionState {
+export interface SessionState {
   sessions: SessionInfo[] | null // null = not yet loaded
   activeSessionId: string | null
 }
@@ -137,3 +137,25 @@ export const useSessionStore = create<SessionState & SessionActions>((set, get) 
     }
   }),
 }))
+
+// --- Selectors (pure functions; usable both in render via
+// useSessionStore(selector) and in event handlers via selector(getState())) ---
+
+/**
+ * Name of the active session, or null when sessions are not loaded yet, no
+ * session is selected, or the selected id is not in the current list (the
+ * transient state during a project switch, where `resetForProjectSwitch`
+ * clears both fields before the destination list arrives).
+ *
+ * Returns a PRIMITIVE rather than the SessionInfo object so that consumers
+ * driven by an effect (the native window title) re-run only on a real name
+ * change: `touchSession` rebuilds the entry on every activity bump without
+ * touching the name.
+ */
+export function selectActiveSessionName(state: SessionState): string | null {
+  if (state.sessions === null || state.activeSessionId === null) return null
+  const active = state.sessions.find((sess) => sess.id === state.activeSessionId)
+  if (!active) return null
+  const name = active.name.trim()
+  return name === '' ? null : name
+}

--- a/specs/architecture/layers.md
+++ b/specs/architecture/layers.md
@@ -95,6 +95,9 @@ TypeScript/React application. Communicates with Go exclusively through:
 
 1. **RPC**: `window.go.desktop.App.*` — async promise-based calls
 2. **Events**: `window.runtime.EventsOn/EventsEmit` — real-time streaming
+3. **Window control**: `window.runtime.WindowSetTitle` — native window state driven from UI state (the title tracks the active project/session)
+
+All three go through the single gateway `frontend/src/api/runtime.ts`; components and hooks never touch `window.runtime` or `window.go` directly.
 
 No direct Go imports. Auto-generated bindings at `frontend/wailsjs/go/desktop/App.{js,d.ts}`.
 


### PR DESCRIPTION
## Why

The Wails window title was the static string `"c0wrk"`, set once at startup in
`main.go` and never updated. Nothing in the title bar, the taskbar or the
window switcher distinguished one c0wrk window from another — or told you
which project you were looking at. IDEs put that context in the title; this
does the same.

```
c0wrk                              nothing active (startup)
c0wrk - MyProject                  project active, no session selected
c0wrk - MyProject - Refactor auth  full context
c0wrk - CHAT - Quick question      No Project pseudo-project
```

## Approach

The title is driven from the **frontend**, not from Go.

`backend` is deliberately Wails-agnostic — `emitEvent` is injected from
`desktop` (`frontend_api.go:140`), so it has no window handle. `desktop` owns
the Wails context but knows neither the active session nor either entity's
name. Assembling the title there would mean rebuilding that join from four
separate events under its own lock, and it still would not see the optimistic
local rename `ProjectSelector` performs (`ProjectSelector.tsx:107`).

The two stores already hold exactly the derived state the title needs, and the
lifecycle events already land there — `project:switched`, `project:renamed`,
`project:deleted`, `session:renamed` (the last one is also how background
auto-titling arrives, `useSessionLoader.ts:101`). So one derived effect covers
startup, project switching, session switching, both renames and deletion, with
no state of its own.

### Design notes

- **`CHAT`, not `No Project`.** The No Project pseudo-project is stored as
  `"No Project"` (`manager.go:58`) but the UI calls that mode CHAT, and the
  title should match what the user sees in the sidebar toggle.
- **Selectors return primitives, not store objects.** The title effect must
  re-run only when the visible text changes; `touchSession` and `setProjects`
  rebuild entries on every activity bump, so an object-returning selector
  would fire the effect for changes the title cannot show. There is a test
  pinning this.
- **Session names are shown as-is,** including the default
  `Session 4f3a1b2c` (`manager.go:1046`), matching the sidebar. Auto-titling
  replaces it through `session:renamed` and the title follows.
- **`setWindowTitle` no-ops without a live runtime** instead of throwing like
  the neighbouring wrappers in `api/runtime.ts` — the title is a cosmetic side
  effect driven from a `useEffect`, and hook tests run under jsdom with no
  `window.runtime`. It mirrors what `subscribe` already does.
- **A transient two-segment title during a project switch is accepted.**
  `useProjectSwitchState.ts:82` clears session state before the destination
  list arrives, so for one RPC round-trip the title reads
  `c0wrk - NewProject`. That is honest — no session is selected yet — and
  cheaper than holding a stale segment. A test pins the behaviour so it is not
  later mistaken for a regression.

## Changes

| File | What |
| --- | --- |
| `frontend/src/hooks/useWindowTitle.ts` | The hook and the pure `buildWindowTitle` |
| `frontend/src/hooks/useWindowTitle.test.ts` | 18 tests |
| `frontend/src/api/runtime.ts` | `setWindowTitle` wrapper + `WindowSetTitle` in the runtime type |
| `frontend/src/stores/projectStore.ts` | `CHAT_LABEL`, `selectTitleScope` |
| `frontend/src/stores/sessionStore.ts` | `selectActiveSessionName`; `SessionState` exported so the selector's signature is nameable |
| `frontend/src/App.tsx` | Mounts the hook at the root, next to the other global hooks |
| `specs/architecture/layers.md` | Frontend↔Go boundary now lists a third channel |

The static `Title: "c0wrk"` in `main.go:102` is left alone — it is the title
before React mounts.

### Spec note

`specs/architecture/layers.md` described the frontend↔Go boundary as exactly
two channels, RPC and Events. Window control is a third. The spec now lists it
and names `frontend/src/api/runtime.ts` as the single gateway for all three.

## Verification

- 18 new tests; the full frontend suite is green (177 files / 2369 tests), as
  are `tsc -b` and ESLint.
- Verified live against a packaged build (`wails build -tags webkit2_41`) run
  with an isolated `HOME` and a seeded project/session, reading the title back
  from the window manager:

  | State | `xdotool getwindowname` |
  | --- | --- |
  | No projects | `c0wrk` |
  | Project active, no session | `c0wrk - TitleProbe` |
  | CHAT mode + session | `c0wrk - CHAT - Quick question` |

  This also confirms `WindowSetTitle` is honoured on GTK/KWin, which was the
  only implementation risk that unit tests could not cover.
